### PR TITLE
SYS-1729: Add script to retrieve FTVA holdings report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ cython_debug/
 
 # Allow devcontainer json
 !.devcontainer/*.json
+
+# Config files with secrets
+*secret*

--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ $ docker compose run ftva_data python
 ```
 
 Some data sources require API keys. Get a copy of the relevant configuration file from a teammate and put it in the top level directory of the project.
+
+## Scripts
+
+### Retrieve FTVA holdings data from Alma
+
+```python get_ftva_holdings_report.py [-h] --config_file CONFIG_FILE --output_file OUTPUT_FILE```

--- a/get_ftva_holdings_report.py
+++ b/get_ftva_holdings_report.py
@@ -26,7 +26,7 @@ def _get_config(config_file_name: str) -> dict:
     return config
 
 
-def get_ftva_holdings_report(analytics_api_key: str, report_path: str) -> dict:
+def get_ftva_holdings_report(analytics_api_key: str, report_path: str) -> list[dict]:
     """Gets the FTVA holdings report data from Alma analytics.
     Path to file is hard-coded.
     """
@@ -36,7 +36,7 @@ def get_ftva_holdings_report(analytics_api_key: str, report_path: str) -> dict:
     return report
 
 
-def write_report_to_file(report: dict, output_file_name: str) -> None:
+def write_report_to_file(report: list[dict], output_file_name: str) -> None:
     """Writes report to a CSV file, output_file_name."""
     keys = report[0].keys()
     with open(output_file_name, "w") as f:

--- a/get_ftva_holdings_report.py
+++ b/get_ftva_holdings_report.py
@@ -1,0 +1,58 @@
+import argparse
+import tomllib
+from csv import DictWriter
+from alma_api_client import AlmaAnalyticsClient
+
+
+def _get_args() -> argparse.Namespace:
+    """Returns the command-line arguments for this program."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config_file", help="Path to configuration file", required=True
+    )
+    parser.add_argument(
+        "--output_file",
+        help="Path to CSV output file which will be written from report data",
+        required=True,
+    )
+    args = parser.parse_args()
+    return args
+
+
+def _get_config(config_file_name: str) -> dict:
+    """Returns configuration for this program, loaded from TOML file."""
+    with open(config_file_name, "rb") as f:
+        config = tomllib.load(f)
+    return config
+
+
+def get_ftva_holdings_report(analytics_api_key: str, report_path: str) -> dict:
+    """Gets the FTVA holdings report data from Alma analytics.
+    Path to file is hard-coded.
+    """
+    aac = AlmaAnalyticsClient(analytics_api_key)
+    aac.set_report_path(report_path)
+    report = aac.get_report()
+    return report
+
+
+def write_report_to_file(report: dict, output_file_name: str) -> None:
+    """Writes report to a CSV file, output_file_name."""
+    keys = report[0].keys()
+    with open(output_file_name, "w") as f:
+        writer = DictWriter(f, keys)
+        writer.writeheader()
+        writer.writerows(report)
+
+
+def main() -> None:
+    args = _get_args()
+    config = _get_config(args.config_file)
+    analytics_api_key = config["alma_config"]["analytics_api_key"]
+    report_path = config["alma_config"]["ftva_holdings_report"]
+    report = get_ftva_holdings_report(analytics_api_key, report_path)
+    write_report_to_file(report, args.output_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements [SYS-1729](https://uclalibrary.atlassian.net/browse/SYS-1729).

This PR adds a script to retrieve FTVA holdings data from Alma Analytics, writing it to a CSV file for later analysis and use.

```docker compose run ftva_data python get_ftva_holdings_report.py [-h] --config_file CONFIG_FILE --output_file OUTPUT_FILE```

The configuration file contains the Alma API key for Analytics and the path to the Analytics report.  I expect we'll extend this file with other secrets and configuration information as the project evolves.  Please ask me for a copy of the current file.

The script lays out the general approach I want to take, with greater modularity and shorter, more focused `main` methods.  Some of the supporting methods could be moved to a `utils` module, but we'll do that as needed.

Tests: None, this just fetches a report and writes it to a file as CSV.  The script takes around 5 minutes to run, and the resulting file currently (today's data) has 368212 rows (1 header, the rest data).


[SYS-1729]: https://uclalibrary.atlassian.net/browse/SYS-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ