### PR TITLE
SYS-1728: Categorize Alma record matches based on criteria matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ cython_debug/
 *.json
 *.mrc
 *.tsv
+*.txt
 *.xlsx
 *.xls
 *.xml

--- a/get_ftva_alma_data.py
+++ b/get_ftva_alma_data.py
@@ -1,5 +1,7 @@
 import argparse
+from collections import Counter
 import logging
+from pprint import pprint
 import re
 import spacy
 import spacy.lang
@@ -276,9 +278,14 @@ def main() -> None:
     bib_data = add_director_data(bib_data, model)
 
     # For now, check each record here; probably move to method, maybe merge with the above 2?
+    criteria_list = []
     for record in bib_data:
         criteria = get_criteria(record)
+        c_string = " ".join(criteria)
+        criteria_list.append(c_string)
         print(record["bib_id"], criteria)
+    d = Counter(criteria_list)
+    pprint({key: d[key] for key in sorted(d)})
 
     # TODO: Helpful during development, probably will remove later;
     # if so, args.output_file may no longer be needed either.

--- a/get_ftva_alma_data.py
+++ b/get_ftva_alma_data.py
@@ -150,6 +150,8 @@ def _dump_all_criteria(bib_data: list[dict]) -> None:
             criteria_list.append(c_string)
             f.write(f"{record["bib_id"]} -> {c_string}\n")
     # Also print counts to stdout, without writing them to file.
+    print("\nCounts of criteria combinations")
+    print("===============================")
     d = Counter(criteria_list)
     pprint({key: d[key] for key in sorted(d)})
 
@@ -167,15 +169,6 @@ def _dump_directors(bib_data: list[dict]) -> None:
                         f"{subfield_code} -> {record[subfield_code]} -> "
                         f"{record["directors"][subfield_code]}\n"
                     )
-
-
-def write_report_to_file(report: list[dict], output_file_name: str) -> None:
-    """Writes report to a CSV file, output_file_name."""
-    keys = report[0].keys()
-    with open(output_file_name, "w") as f:
-        writer = DictWriter(f, keys, delimiter="\t")
-        writer.writeheader()
-        writer.writerows(report)
 
 
 def get_criteria(record: dict) -> str:
@@ -228,7 +221,7 @@ def get_criteria(record: dict) -> str:
 
 
 def _get_all_criteria(record: dict) -> list[str]:
-    # TODO: REMOVE
+    # TODO: Remove after debugging.
     """Categorizes record against the criteria in 6.x of the Criteria Matrix.
     Returns a list of all matching criteria, for debugging / review only.
     """
@@ -416,10 +409,24 @@ def get_director_data(field_data: dict, model: spacy.Language) -> dict:
     return director_data
 
 
+def write_data_to_file(report: list[dict], output_file_name: str) -> None:
+    """Writes data to a CSV file, output_file_name."""
+    keys = report[0].keys()
+    with open(output_file_name, "w") as f:
+        writer = DictWriter(f, keys, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(report)
+
+
 def main() -> None:
     args = _get_args()
     model = spacy.load("en_core_web_md")
     bib_data = get_bib_data(args.input_file, model)
+
+    # TODO: Something useful with this... currently just shows usage.
+    for record in bib_data:
+        criteria = get_criteria(record)
+        print(record["bib_id"], criteria)
 
     # Useful during debugging
     if args.dump_directors:
@@ -429,7 +436,7 @@ def main() -> None:
 
     # TODO: Helpful during development, probably will remove later;
     # if so, args.output_file may no longer be needed either.
-    write_report_to_file(bib_data, args.output_file)
+    write_data_to_file(bib_data, args.output_file)
 
 
 if __name__ == "__main__":

--- a/get_ftva_alma_data.py
+++ b/get_ftva_alma_data.py
@@ -1,0 +1,236 @@
+import argparse
+
+# import json
+import pickle
+import re
+import spacy
+from csv import DictWriter
+from pprint import pprint
+from pymarc import MARCReader, Record
+import spacy.lang
+
+
+def _get_args() -> argparse.Namespace:
+    """Returns the command-line arguments for this program."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input_file",
+        help="Path to input file containing MARC bib records",
+        required=True,
+    )
+    parser.add_argument(
+        "--output_file",
+        help="Path to output file of parsed data",
+        required=True,
+    )
+    args = parser.parse_args()
+    return args
+
+
+def _get_bib_id(record: Record) -> str:
+    fld = record.get("001")
+    if fld:
+        bib_id = fld.data
+    else:
+        bib_id = None
+    return bib_id
+
+
+def _get_language(record: Record) -> str:
+    fld = record.get("008")
+    if fld:
+        language = fld.data[35:38]
+    else:
+        language = "###"
+    return language
+
+
+def _get_subfields(record: Record, field_tag: str, subfield_code: str) -> list:
+    # field_tag may represent a repeatable field, so get all instances.
+    # subfield_code may be repeated within each field, or occur just once per field.
+    # Currently, we don't need to maintain the specific field:subfield relationship.
+    subfields = []
+    fields = record.get_fields(field_tag)
+    for field in fields:
+        subfields.extend(field.get_subfields(subfield_code))
+    return subfields
+
+
+def _get_single_subfield(record: Record, field_tag: str, subfield_code: str) -> list:
+    # Return just the first subfield of any found, as a list to keep a consistent
+    # interface with _get_subfields().
+    subfields = _get_subfields(record, field_tag, subfield_code)
+    if subfields:
+        return [subfields[0]]
+    else:
+        return []
+
+
+def _get_field_data(record: Record) -> dict:
+    bib_id = _get_bib_id(record)
+    language = _get_language(record)
+    # 245 is not repeatable; 245 $a and $c are not repeatable, but 245 $p is.
+    f245a = _get_single_subfield(record, "245", "a")
+    f245c = _get_single_subfield(record, "245", "c")
+    f245n = _get_subfields(record, "245", "n")
+    f245p = _get_subfields(record, "245", "p")
+    # 246 is repeatable, though 246 $a is not
+    f246a = _get_subfields(record, "246", "a")
+    # 250 is repeatable, though 250 $a is not
+    f250a = _get_subfields(record, "250", "a")
+    # 505 is repeatable; 505 $a is not, but 505 $r is
+    f505a = _get_subfields(record, "505", "a")
+    f505r = _get_subfields(record, "505", "r")
+    field_data = {
+        "bib_id": bib_id,
+        "language": language,
+        "f245a": f245a,
+        "f245c": f245c,
+        "f245n": f245n,
+        "f245p": f245p,
+        "f246a": f246a,
+        "f250a": f250a,
+        "f505a": f505a,
+        "f505r": f505r,
+        # Directors will be added later.
+        "directors": {},
+    }
+    return field_data
+
+
+def print_stats(data: list) -> None:
+    # Quick list of unique 245 $p, which currently has up to 2 values
+    print("f245p values:")
+    print("==================")
+    values = [row["f245p"] for row in data]
+    unique_values = list(map(pickle.loads, dict.fromkeys(map(pickle.dumps, values))))
+    pprint(unique_values, width=132)
+    print("==================")
+
+    # Quick check of list sizes
+    for key, value in data[0].items():
+        if isinstance(value, list):
+            print(f"Max values in {key}: ", max([len(row[key]) for row in data]))
+
+
+def write_report_to_file(report: list[dict], output_file_name: str) -> None:
+    """Writes report to a CSV file, output_file_name."""
+    keys = report[0].keys()
+    with open(output_file_name, "w") as f:
+        writer = DictWriter(f, keys, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(report)
+
+
+def characterize_record():
+    pass
+
+
+def _debug_print_leading_director_words(segment: str) -> None:
+    # TODO: Remove after debugging, or make the check useful.
+    # Find words (alphanumeric strings) and spaces before DIRECTOR.
+    pattern = r"[a-zA-Z0-9_ ]+(?=\s+DIRECTOR)"
+    matches = re.findall(pattern, segment, re.IGNORECASE)
+    if matches:
+        print(matches, segment)
+
+
+def _has_director(segment: str) -> bool:
+    wanted = ["directed", "director", "a film by"]
+    unwanted = [
+        "director of interior photography",
+        "exteriors directed by",
+        "revue director",
+        "staging director",
+        "technical director",
+        "TV director",
+        "television director",
+    ]
+    # Reject segment if it has any unwanted term.
+    for val in unwanted:
+        if val in segment:
+            return False
+    # Still here? Check for wanted terms.
+    for val in wanted:
+        if val in segment:
+            return True
+    # Didn't prove there was an acceptable director term.
+    return False
+
+
+def _has_multiple_directors(record: dict) -> bool:
+    """Returns True if a record has more than 1 director, False otherwise."""
+    directors: dict = record["directors"]
+    # This should contain multiple keys, one for each record element in which
+    # director(s) were found. Each key has a list of directors, which may be empty.
+    director_count = sum([len(value) for value in directors.values()])
+    return director_count > 1
+
+
+def _get_director_segments(subfields: list[str]) -> list[str]:
+    """Checks each segment (delimited by ";", if a subfield contains multiple segments)
+    of each subfield and returns those which appear to contain information about directors.
+    """
+    combined = " ".join(subfields)
+    segments = [segment.strip() for segment in combined.split(";")]
+    return [segment for segment in segments if _has_director(segment)]
+
+
+def get_names(segments: list[str], model: spacy.Language) -> list[str]:
+    """Returns a set of personal names identified by spacy from the
+    pre-qualified list of data segments from a MARC record.
+    """
+    # Use a set to automatically de-duplicate.
+    names: set[str] = set()
+    for segment in segments:
+        doc = model(segment)
+        names.update([ent.text for ent in doc.ents if ent.label_ == "PERSON"])
+    # Return it as a list, for better consistency later on.
+    return list(names)
+
+
+def get_bib_data(marc_file: str) -> list[dict]:
+    bib_data: list[dict] = []
+    with open(marc_file, "rb") as f:
+        reader = MARCReader(f)
+        for record in reader:
+            field_data = _get_field_data(record)
+            bib_data.append(field_data)
+    return bib_data
+
+
+def add_director_data(bib_data: list[dict], model: spacy.Language) -> list[dict]:
+    """Adds a list of directors' names to each record in bib_data."""
+    for record in bib_data:
+        # Check 245 $c and $p, though $p currently does not have any director information.
+        # We need to know whether directors found in 245 $c or 245 $p (or both).
+        for element in ["f245c", "f245p"]:
+            subfield_data: list = record[element]
+            # Returns empty list if no potential directors found.
+            director_segments = _get_director_segments(subfield_data)
+            if director_segments:
+                directors = get_names(director_segments, model)
+            else:
+                directors = []
+            # record["directors"] was initialized to {} in _get_field_data()
+            record["directors"][element] = directors
+
+    return bib_data
+
+
+def main() -> None:
+    args = _get_args()
+    model = spacy.load("en_core_web_md")
+    bib_data = get_bib_data(args.input_file)
+
+    # Helpful during development
+    write_report_to_file(bib_data, args.output_file)
+
+    # Helpful during development
+    # print_stats(bib_data)
+
+    bib_data = add_director_data(bib_data, model)
+
+
+if __name__ == "__main__":
+    main()

--- a/get_ftva_alma_data.py
+++ b/get_ftva_alma_data.py
@@ -24,6 +24,18 @@ def _get_args() -> argparse.Namespace:
         help="Path to output file of parsed data",
         required=True,
     )
+    parser.add_argument(
+        "--dump_criteria",
+        help="Dump all assigned criteria for each record to all_criteria.txt, for debugging",
+        required=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "--dump_directors",
+        help="Dump all director segments and names to alL_directors.txt, for debugging",
+        required=False,
+        action="store_true",
+    )
     args = parser.parse_args()
     return args
 
@@ -50,6 +62,7 @@ def _get_logger(name: str | None = None) -> logging.Logger:
 
 
 def _get_bib_id(record: Record) -> str:
+    """Returns the bibliographic id of the MARC record."""
     fld = record.get("001")
     if fld:
         bib_id = fld.data
@@ -59,6 +72,7 @@ def _get_bib_id(record: Record) -> str:
 
 
 def _get_language(record: Record) -> str:
+    """Returns the primary language code of the MARC record."""
     fld = record.get("008")
     if fld:
         language = fld.data[35:38]
@@ -68,9 +82,11 @@ def _get_language(record: Record) -> str:
 
 
 def _get_subfields(record: Record, field_tag: str, subfield_code: str) -> list:
-    # field_tag may represent a repeatable field, so get all instances.
-    # subfield_code may be repeated within each field, or occur just once per field.
-    # Currently, we don't need to maintain the specific field:subfield relationship.
+    """Returns a list of subfield values from the MARC record.
+    field_tag may represent a repeatable field, so get all instances.
+    subfield_code may be repeated within each field, or occur just once per field.
+    Does not maintain the specific field:subfield relationship.
+    """
     subfields = []
     fields = record.get_fields(field_tag)
     for field in fields:
@@ -79,8 +95,9 @@ def _get_subfields(record: Record, field_tag: str, subfield_code: str) -> list:
 
 
 def _get_single_subfield(record: Record, field_tag: str, subfield_code: str) -> list:
-    # Return just the first subfield of any found, as a list to keep a consistent
-    # interface with _get_subfields().
+    """Returns just the first subfield of any found, as a list to keep a consistent
+    interface with _get_subfields().
+    """
     subfields = _get_subfields(record, field_tag, subfield_code)
     if subfields:
         return [subfields[0]]
@@ -89,6 +106,9 @@ def _get_single_subfield(record: Record, field_tag: str, subfield_code: str) -> 
 
 
 def _get_field_data(record: Record) -> dict:
+    """Returns a dictionary of specific data from the MARC bib record. Currently
+    this is only what's needed for evaluating criteria for categorization.
+    """
     bib_id = _get_bib_id(record)
     language = _get_language(record)
     # 245 is not repeatable; 245 $a and $c are not repeatable, but 245 $p is.
@@ -114,10 +134,39 @@ def _get_field_data(record: Record) -> dict:
         "f250a": f250a,
         "f505a": f505a,
         "f505r": f505r,
-        # Directors will be added later.
-        "directors": {},
     }
     return field_data
+
+
+def _dump_all_criteria(bib_data: list[dict]) -> None:
+    """Prints all criteria satisfied for each record.
+    Useful for debugging.
+    """
+    with open("all_criteria.txt", "w") as f:
+        criteria_list = []
+        for record in bib_data:
+            criteria = _get_all_criteria(record)
+            c_string = ", ".join(criteria)
+            criteria_list.append(c_string)
+            f.write(f"{record["bib_id"]} -> {c_string}\n")
+    # Also print counts to stdout, without writing them to file.
+    d = Counter(criteria_list)
+    pprint({key: d[key] for key in sorted(d)})
+
+
+def _dump_directors(bib_data: list[dict]) -> None:
+    """Dumps all director information to hard-coded file.
+    Useful for debugging.
+    """
+    with open("all_directors.txt", "w") as f:
+        for record in bib_data:
+            # We can trust these keys to exist, though they may be empty.
+            for subfield_code in ["f245c", "f245p"]:
+                if record["directors"][subfield_code]:
+                    f.write(
+                        f"{subfield_code} -> {record[subfield_code]} -> "
+                        f"{record["directors"][subfield_code]}\n"
+                    )
 
 
 def write_report_to_file(report: list[dict], output_file_name: str) -> None:
@@ -129,7 +178,60 @@ def write_report_to_file(report: list[dict], output_file_name: str) -> None:
         writer.writerows(report)
 
 
-def get_criteria(record: dict) -> list[str]:
+def get_criteria(record: dict) -> str:
+    """Categorizes record against the criteria in 6.x of the Criteria Matrix.
+    Returns the first matching criterion.
+    """
+    f245c_director_count = len(record["directors"]["f245c"])
+    f245p_director_count = len(record["directors"]["f245p"])
+    # 6.1: Single director in 245 $c, English, plus other stuff.
+    if (
+        f245c_director_count == 1
+        and record["f245a"]
+        and not record["f245p"]
+        and not record["f250a"]
+        and record["language"] == "eng"
+    ):
+        return "6.1"
+
+    # 6.2: Single director in 245 $c, NOT English, plus other stuff.
+    if (
+        f245c_director_count == 1
+        and record["f245a"]
+        and (record["f250a"] or record["language"] != "eng")
+    ):
+        return "6.2"
+
+    # 6.3: Single director in 245 $c, check other 245 subfields.
+    if f245c_director_count == 1 and (
+        (record["f245a"] and record["f245p"]) or (record["f245a"] and record["f245n"])
+    ):
+        return "6.3"
+
+    # 6.4: Multiple directors in 245 $c, plus other stuff.
+    if (record["f245a"] and f245c_director_count > 1) or (
+        record["f245a"] and (record["f505a"] or record["f505r"])
+    ):
+        return "6.4"
+
+    # 6.5: No director in 245 $c.
+    if f245c_director_count == 0:
+        return "6.5"
+
+    # 6.6: Director(s?) in 245 $p.
+    if f245p_director_count > 0:
+        return "6.6"
+
+    # 6.7: Whatever's left after checking the above.
+    # No criteria added already.
+    return "6.7"
+
+
+def _get_all_criteria(record: dict) -> list[str]:
+    # TODO: REMOVE
+    """Categorizes record against the criteria in 6.x of the Criteria Matrix.
+    Returns a list of all matching criteria, for debugging / review only.
+    """
     criteria = []
     f245c_director_count = len(record["directors"]["f245c"])
     f245p_director_count = len(record["directors"]["f245p"])
@@ -159,7 +261,9 @@ def get_criteria(record: dict) -> list[str]:
 
     # 6.4: Multiple directors in 245 $c, plus other stuff.
     if (record["f245a"] and f245c_director_count > 1) or (
-        record["f245a"] and (record["f505a"] or record["f505r"])
+        record["f245a"]
+        and f245c_director_count > 1
+        and (record["f505a"] or record["f505r"])
     ):
         criteria.append("6.4")
 
@@ -189,6 +293,10 @@ def _debug_print_leading_director_words(segment: str) -> None:
 
 
 def _has_director(segment: str) -> bool:
+    """Determines whether segment (a piece of text extracted from MARC data)
+    should contain a director's name, based on the presence and/or absence of
+    certain words.
+    """
     wanted = ["directed", "director", "a film by"]
     unwanted = [
         "director of interior photography",
@@ -220,6 +328,29 @@ def _get_director_segments(subfields: list[str]) -> list[str]:
     return [segment for segment in segments if _has_director(segment)]
 
 
+def _fix_name_suffix(names: list[str]) -> list[str]:
+    """Fixes specific case where a single person's name has had the 'Jr.'
+    suffix incorrectly identified as a separate 'name'.
+    If more general cases are found, this should be re-implemented
+    via spaCy (re)training.
+    """
+    # This currently is the only suffix being handled.
+    suffix = "Jr."
+
+    # Caller should have done this, but be sure.
+    if len(names) != 2 or suffix not in names:
+        raise ValueError(f"Unable to handle name and {suffix}: {names}")
+
+    # Order of values in names is not guaranteed, but one value will be "Jr."
+    # and one will not.  Remove "Jr." and take the remaining value.
+    # Must be done in 2 steps, since list.remove() always returns None.
+    names.remove(suffix)
+    main_name = names[0]
+
+    # Return the single now-combined name as a list to maintain expected interface.
+    return [f"{main_name}, {suffix}"]
+
+
 def get_names(segments: list[str], model: spacy.Language) -> list[str]:
     """Returns a set of personal names identified by spacy from the
     pre-qualified list of data segments from a MARC record.
@@ -230,62 +361,71 @@ def get_names(segments: list[str], model: spacy.Language) -> list[str]:
         doc = model(segment)
         names.update([ent.text for ent in doc.ents if ent.label_ == "PERSON"])
 
+    # Convert set to list, for better consistency with other data later on.
+    names = list(names)
+
     # If no names were found, despite them being expected in segments, log a message.
     if len(names) == 0:
         logger.warning(f"No names found in {segments}: manual review needed.")
+
+    # spacy model does not handle "Jr." correctly - possibly others.
+    # TODO: Handle these via log and (re)training the model?
+    if len(names) == 2 and "Jr." in names:
+        names = _fix_name_suffix(names)
+
     # TODO: Possibly add other data checks here?
 
-    # Return a list, for better consistency later on.
-    return list(names)
+    return names
 
 
-def get_bib_data(marc_file: str) -> list[dict]:
+def get_bib_data(marc_file: str, model: spacy.Language) -> list[dict]:
+    """Returns a list of data extracted from a file of binary MARC bibliographic
+    records.  The relevant data for each record is in a dictionary created by
+    _get_field_data().
+    """
     bib_data: list[dict] = []
     with open(marc_file, "rb") as f:
         reader = MARCReader(f)
         for record in reader:
             field_data = _get_field_data(record)
+            # Add director information, derived from field_data.
+            field_data["directors"] = get_director_data(field_data, model)
             bib_data.append(field_data)
 
     logger.info(f"Processed {len(bib_data)} records from {marc_file}")
     return bib_data
 
 
-def add_director_data(bib_data: list[dict], model: spacy.Language) -> list[dict]:
-    """Adds a list of directors' names to each record in bib_data."""
-    for record in bib_data:
-        # Check 245 $c and $p, though $p currently does not have any director information.
-        # We need to know whether directors found in 245 $c or 245 $p (or both).
-        for element in ["f245c", "f245p"]:
-            subfield_data: list = record[element]
-            # Returns empty list if no potential directors found.
-            director_segments = _get_director_segments(subfield_data)
-            if director_segments:
-                directors = get_names(director_segments, model)
-            else:
-                directors = []
-            # record["directors"] was initialized to {} in _get_field_data()
-            record["directors"][element] = directors
+def get_director_data(field_data: dict, model: spacy.Language) -> dict:
+    """Returns a list of directors' names based on elements of field_data, using
+    the given model to identify personal name entities.
+    """
+    # Check 245 $c and $p, though $p currently does not have any director information.
+    # We need to know whether directors found in 245 $c or 245 $p (or both).
+    director_data = {}
+    for element in ["f245c", "f245p"]:
+        subfield_data: list = field_data[element]
+        # Returns empty list if no potential directors found.
+        director_segments = _get_director_segments(subfield_data)
+        if director_segments:
+            directors = get_names(director_segments, model)
+        else:
+            directors = []
+        director_data[element] = directors
 
-    return bib_data
+    return director_data
 
 
 def main() -> None:
     args = _get_args()
     model = spacy.load("en_core_web_md")
-    # TODO: Consider one call to do these two steps?
-    bib_data = get_bib_data(args.input_file)
-    bib_data = add_director_data(bib_data, model)
+    bib_data = get_bib_data(args.input_file, model)
 
-    # For now, check each record here; probably move to method, maybe merge with the above 2?
-    criteria_list = []
-    for record in bib_data:
-        criteria = get_criteria(record)
-        c_string = " ".join(criteria)
-        criteria_list.append(c_string)
-        print(record["bib_id"], criteria)
-    d = Counter(criteria_list)
-    pprint({key: d[key] for key in sorted(d)})
+    # Useful during debugging
+    if args.dump_directors:
+        _dump_directors(bib_data)
+    if args.dump_criteria:
+        _dump_all_criteria(bib_data)
 
     # TODO: Helpful during development, probably will remove later;
     # if so, args.output_file may no longer be needed either.

--- a/get_ftva_alma_data.py
+++ b/get_ftva_alma_data.py
@@ -201,23 +201,41 @@ def get_criteria(record: dict) -> str:
     ):
         return "6.3"
 
-    # 6.4: Multiple directors in 245 $c, plus other stuff.
-    if (record["f245a"] and f245c_director_count > 1) or (
-        record["f245a"] and (record["f505a"] or record["f505r"])
+    # 6.4: Multiple directors in 245 $c, English, plus other stuff.
+    # TODO: Thelma still reviewing, uncomment / change as needed.
+    if (
+        f245c_director_count > 1
+        and record["f245a"]
+        and not record["f250a"]
+        and record["language"] == "eng"
     ):
         return "6.4"
 
-    # 6.5: No director in 245 $c.
-    if f245c_director_count == 0:
+    # 6.5: Multiple directors in 245 $c, NOT English, plus other stuff.
+    if (
+        f245c_director_count > 1
+        and record["f245a"]
+        and (record["f250a"] or record["language"] != "eng")
+    ):
         return "6.5"
 
-    # 6.6: Director(s?) in 245 $p.
-    if f245p_director_count > 0:
+    # 6.6: Multiple directors in 245 $c, check other 245 subfields.
+    if f245c_director_count > 1 and (
+        (record["f245a"] and record["f245p"]) or (record["f245a"] and record["f245n"])
+    ):
         return "6.6"
 
-    # 6.7: Whatever's left after checking the above.
-    # No criteria added already.
-    return "6.7"
+    # 6.7: No director in 245 $c.
+    if f245c_director_count == 0:
+        return "6.7"
+
+    # 6.8: Director(s?) in 245 $p.
+    if f245p_director_count > 0:
+        return "6.8"
+
+    # 6.9: Whatever's left after checking the above.
+    # No criteria matched already.
+    return "6.9"
 
 
 def _get_all_criteria(record: dict) -> list[str]:
@@ -252,26 +270,42 @@ def _get_all_criteria(record: dict) -> list[str]:
     ):
         criteria.append("6.3")
 
-    # 6.4: Multiple directors in 245 $c, plus other stuff.
-    if (record["f245a"] and f245c_director_count > 1) or (
-        record["f245a"]
-        and f245c_director_count > 1
-        and (record["f505a"] or record["f505r"])
+    # 6.4: Multiple directors in 245 $c, English, plus other stuff.
+    # TODO: Thelma still reviewing, uncomment / change as needed.
+    if (
+        f245c_director_count > 1
+        and record["f245a"]
+        and not record["f250a"]
+        and record["language"] == "eng"
     ):
         criteria.append("6.4")
 
-    # 6.5: No director in 245 $c.
-    if f245c_director_count == 0:
+    # 6.5: Multiple directors in 245 $c, NOT English, plus other stuff.
+    if (
+        f245c_director_count > 1
+        and record["f245a"]
+        and (record["f250a"] or record["language"] != "eng")
+    ):
         criteria.append("6.5")
 
-    # 6.6: Director(s?) in 245 $p.
-    if f245p_director_count > 0:
+    # 6.6: Multiple directors in 245 $c, check other 245 subfields.
+    if f245c_director_count > 1 and (
+        (record["f245a"] and record["f245p"]) or (record["f245a"] and record["f245n"])
+    ):
         criteria.append("6.6")
 
-    # 6.7: Whatever's left after checking the above.
-    # No criteria added already.
-    if not criteria:
+    # 6.7: No director in 245 $c.
+    if f245c_director_count == 0:
         criteria.append("6.7")
+
+    # 6.8: Director(s?) in 245 $p.
+    if f245p_director_count > 0:
+        criteria.append("6.8")
+
+    # 6.9: Whatever's left after checking the above.
+    # No criteria matched already.
+    if not criteria:
+        criteria.append("6.9")
 
     return criteria
 

--- a/get_ftva_alma_data.py
+++ b/get_ftva_alma_data.py
@@ -150,10 +150,8 @@ def get_criteria(record: dict) -> list[str]:
         criteria.append("6.2")
 
     # 6.3: Single director in 245 $c, check other 245 subfields.
-    if (
-        f245c_director_count == 1
-        and (record["f245a"] and record["f245p"])
-        or (record["f245a"] and record["f245n"])
+    if f245c_director_count == 1 and (
+        (record["f245a"] and record["f245p"]) or (record["f245a"] and record["f245n"])
     ):
         criteria.append("6.3")
 


### PR DESCRIPTION
Implements [SYS-1728](https://uclalibrary.atlassian.net/browse/SYS-1728).

This PR adds a script, `get_ftva_alma_data.py`:
```
options:
  -h, --help            show this help message and exit
  --input_file INPUT_FILE
                        Path to input file containing MARC bib records
  --output_file OUTPUT_FILE
                        Path to output file of parsed data
  --dump_criteria       Dump all assigned criteria for each record to all_criteria.txt, for debugging
  --dump_directors      Dump all director segments and names to alL_directors.txt, for debugging
```

Its current main purpose is to iterate through the FTVA bib records previously obtained via `get_alma_bib_records.py`, evaluate each one against the relevant criteria (currently 6.x in the [Criteria Matrix](https://docs.google.com/spreadsheets/d/1NwKmLXHYCKGOyBTFmES3ACW2sXV1c-rfd0-Ik0u9N-Q/edit?gid=0#gid=0)), and report the single matching criterion for each record.

The output file (currently required, may remove later) is a tab-delimited file with all of the data elements used for evaluation.  These are specific values extracted from the MARC record, along with a `directors` field listing the names of director(s) identified in the relevant data.

These names are obtained by using the medium-sized core English model with `spaCy`, for named entity recognition.  This model was the most accurate overall, with this set of data: considerably better than the small model, slightly better than the large. The model name is currently hard-coded in the program's `main` method.

The program still contains several methods used for debugging / easier review of transient data.  These probably will be removed later, once the specs stop changing.

There currently are no tests for any of this code - time is getting short.  I hope we can add at least some tests later.

Manual testing:
```
docker compose run ftva_data python get_ftva_alma_data.py \
--input_file ftva_bibs_20250117.mrc \
--output_file ftva_bibs_20250127.tsv \ # or whatever name you want
--dump_directors \
--dump_criteria
```
The last two "dump" arguments are optional, generating `all_directors.txt` and `all_criteria.txt` respectively, useful for checking data.

Running the program generates a time-stamped log file, `get_ftva_alma_data_YYYYMMDD_HH24MISS.log`.  Currently the only thing logged is the number of MARC records processed (1676, in the file I have) and warnings when no names are found in data which should have at least one name (2 such warnings, in current data).

Currently, the program prints each MARC bib id and the single 6.x criterion calculated for it. This obviously will be fed into something useful once we start generating output to send to the MAMS.

If the `--dump_criteria` flag was used, the output also includes "Counts of criteria combinations". These include combinations, again mainly for debugging: we won't use combinations, but it's helpful to know if some records matched multiple criteria.  Record ids can be found in `all_criteria.txt`.

Line counts of the files I get with the above flags:
```
1677 ftva_bibs_20250127.tsv # one for each MARC record, plus header row
1676 all_criteria.txt # one for each MARC record, no header row
 634 all_directors.txt # no header row
```

[SYS-1728]: https://uclalibrary.atlassian.net/browse/SYS-1728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ