### PR TITLE
SYS-1733: spaCy training

### DIFF
--- a/spacy_experiment.py
+++ b/spacy_experiment.py
@@ -80,7 +80,7 @@ def main():
 
     # train custom model
     training_data = load_training_data("training_data.txt")
-    custom_model = train_model(training_data)
+    custom_model = train_model(training_data, medium_model)
     print("custom model:")
     evaluate_model(data, custom_model, "custom_model_output.csv")
 

--- a/spacy_experiment.py
+++ b/spacy_experiment.py
@@ -5,6 +5,9 @@ import csv
 # for type hinting
 from spacy.language import Language
 
+# custom model trained with 20 iterations
+from train_spacy import train_model, load_training_data
+
 
 def find_names(data: list, model: Language) -> dict:
     output_dict = {}
@@ -28,7 +31,7 @@ def find_names(data: list, model: Language) -> dict:
     return output_dict
 
 
-def evaluate_model(data: list, model: Language) -> None:
+def evaluate_model(data: list, model: Language, filename: str) -> None:
     entity_dict = find_names(data, model)
     # get total count of names and other entities
     total_names = 0
@@ -40,7 +43,7 @@ def evaluate_model(data: list, model: Language) -> None:
     print(f"total subfields: {len(entity_dict)}")
     print(f"total names: {total_names}")
     print(f"total other entities: {total_other_entities}")
-    write_output_csv(f"output_{model.meta['name']}.csv", entity_dict)
+    write_output_csv(filename, entity_dict)
 
 
 def write_output_csv(file_name: str, output_dict: dict) -> None:
@@ -71,10 +74,17 @@ def main():
     medium_model = spacy.load("en_core_web_md")
 
     print("small model:")
-    evaluate_model(data, small_model)
+    evaluate_model(data, small_model, "small_model_output.csv")
     print()
     print("medium model:")
-    evaluate_model(data, medium_model)
+    evaluate_model(data, medium_model, "medium_model_output.csv")
+    print()
+
+    # train custom model
+    training_data = load_training_data("training_data.txt")
+    custom_model = train_model(training_data)
+    print("custom model:")
+    evaluate_model(data, custom_model, "custom_model_output.csv")
 
 
 if __name__ == "__main__":

--- a/spacy_experiment.py
+++ b/spacy_experiment.py
@@ -1,12 +1,10 @@
 import json
 import spacy
 import csv
+from train_spacy import train_model, load_training_data
 
 # for type hinting
 from spacy.language import Language
-
-# custom model trained with 20 iterations
-from train_spacy import train_model, load_training_data
 
 
 def find_names(data: list, model: Language) -> dict:

--- a/train_spacy.py
+++ b/train_spacy.py
@@ -1,0 +1,55 @@
+import spacy
+from spacy.training.example import Example
+from spacy.language import Language
+
+
+def load_training_data(file_path: str) -> list:
+    """Load training data from a text file.
+    Data is formatted as text, followed by a newline,
+    followed by a list of names separated by newlines.
+    Each entry is separated by two newlines.
+    """
+
+    with open(file_path, encoding="utf-8") as file:
+        data = file.read().split("\n\n")
+        data = [item.split("\n") for item in data]
+        return data
+
+
+def _format_training_data(data: list) -> list:
+    """Format training data for spacy."""
+    formatted_data = []
+    for item in data:
+        text = item[0]
+        entities = []
+        for name in item[1:]:
+            start = text.find(name)
+            end = start + len(name)
+            entities.append((start, end, "PERSON"))
+        formatted_data.append((text, {"entities": entities}))
+    return formatted_data
+
+
+def train_model(data: list) -> Language:
+    """Train a spacy NER model with the given data, loaded from a text file."""
+    formatted_data = _format_training_data(data)
+
+    nlp = spacy.load("en_core_web_md")
+    # set up pipeline for training
+    if "ner" not in nlp.pipe_names:
+        ner = nlp.add_pipe("ner")
+        nlp.add_pipe(ner, last=True)
+    else:
+        ner = nlp.get_pipe("ner")
+
+    # get names of other pipes to disable them during training
+    other_pipes = [pipe for pipe in nlp.pipe_names if pipe != "ner"]
+    with nlp.disable_pipes(*other_pipes):  # only train NER
+        nlp.resume_training()
+        for itn in range(10):
+            losses = {}
+            for text, annotations in formatted_data:
+                doc = nlp.make_doc(text)
+                example = Example.from_dict(doc, annotations)
+                nlp.update([example], drop=0.5, losses=losses)
+    return nlp


### PR DESCRIPTION
Implements [SYS-1733](https://uclalibrary.atlassian.net/browse/SYS-1733)

Adds a new file, `train_spacy.py`, including functions to train spaCy NER models on known data. These functions train a NER model in memory, creating a `Language` object that can be passed around. 

To demonstrate this, `spacy_experiment.py` has been updated to import the `train_model()` and  `load_training_data()` functions, and to use these to train a custom model to use alongside the existing small and medium NER models. Some small supporting changes were made in the script to support better naming of output files.

The training functions rely on a training file in a specific format. Save the below text as `training_data.txt` (as expected by `spacy_experiment.py`).

```
directors, Ellen Fisher Turk, Andrew Weeks
Ellen Fisher Turk
Andrew Weeks

director, Keven Jonson
Keven Jonson

directed by Cristina Aurora Kotz
Cristina Aurora Kotz

directed by Victor Masayesva, Jr.
Victor Masayesva, Jr.

director, Jack Smight
Jack Smight

directed and written by Blackhorse Lowe
Blackhorse Lowe

conceived and directed by Geo. M. Merrick 
Geo. M. Merrick

directors, Andre Libik, Walon Green
Andre Libik
Walon Green
```

I believe that this data format is easier to maintain than a CSV or JSON file, especially in cases with multiple directors. 

To see this all in action, run the `spacy_experiment.py` script as before: `docker compose run --rm ftva_data python spacy_experiment.py`


[SYS-1733]: https://uclalibrary.atlassian.net/browse/SYS-1733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ