### PR TITLE
SYS-1741: Filemaker API demo script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ USER ftva_data
 COPY --chown=ftva_data:ftva_data . .
 
 # Include local python bin into ftva_data user's path, mostly for pip
-ENV PATH /home/ftva_data/.local/bin:${PATH}
+ENV PATH=/home/ftva_data/.local/bin:${PATH}
 
 # Make sure pip is up to date, and don't complain if it isn't yet
 RUN pip install --upgrade pip --disable-pip-version-check

--- a/README.md
+++ b/README.md
@@ -43,10 +43,32 @@ $ docker compose run ftva_data bash
 $ docker compose run ftva_data python
 ```
 
-Some data sources require API keys. Get a copy of the relevant configuration file from a teammate and put it in the top level directory of the project.
+### Secrets
+
+Some data sources require API keys or other secrets. Get a copy of the relevant configuration file from a teammate and put it in the top level directory of the project.
+
+The config file currently looks like this (with secret values redacted):
+```
+[alma_config]
+alma_api_key = "SECRET"
+analytics_api_key = "SECRET"
+ftva_holdings_report =  "/shared/University of California Los Angeles (UCLA) 01UCS_LAL/Cataloging/Reports/API/FTVA Holdings"
+
+[filemaker]
+api_version="vLatest"
+database="Inventory for Labeling"
+layout="InventoryForLabeling_ReadOnly_API"
+password="YOUR_PASSWORD"
+url = "https://adam.cinema.ucla.edu"
+user="YOUR_NAME"
+```
 
 ## Scripts
 
 ### Retrieve FTVA holdings data from Alma
 
 ```python get_ftva_holdings_report.py [-h] --config_file CONFIG_FILE --output_file OUTPUT_FILE```
+
+### Proof of concept for Filemaker API (find and display data)
+
+```python filemaker_api_test.py [-h] --config_file CONFIG_FILE```

--- a/filemaker_api_test.py
+++ b/filemaker_api_test.py
@@ -1,0 +1,61 @@
+import argparse
+import fmrest
+import tomllib
+
+
+def _get_args() -> argparse.Namespace:
+    """Returns the command-line arguments for this program."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config_file",
+        help="Path to config file with Filemaker connection info",
+        required=True,
+    )
+    args = parser.parse_args()
+    return args
+
+
+def _get_config(config_file_name: str) -> dict:
+    """Returns configuration for this program, loaded from TOML file."""
+    with open(config_file_name, "rb") as f:
+        config = tomllib.load(f)
+    return config
+
+
+def main() -> None:
+    """Proof of concept / demo code for basic Filemaker API use.
+    See https://github.com/davidhamann/python-fmrest/tree/master/examples
+    """
+    args = _get_args()
+    config = _get_config(args.config_file)
+    fm_config = config["filemaker"]
+    fms = fmrest.Server(
+        url=fm_config["url"],
+        user=fm_config["user"],
+        password=fm_config["password"],
+        database=fm_config["database"],
+        layout=fm_config["layout"],
+        api_version=fm_config["api_version"],
+    )
+
+    fms.login()
+
+    find_query = [{"inventory_id": "16032"}]  # 1 record
+    # find_query = [{"director": "Alan Smithee"}]  # 9 records, currently
+    results = fms.find(find_query)
+
+    for rec_number, record in enumerate(results, start=1):
+        print(f"===== Data for record number {rec_number} =====")
+        # record is not a dict, does not have .items()
+        # print(len(record.keys()))
+        # print(len(record.values()))
+        print(record["portal_Labeling Database_InvID"])
+        for key in record.keys():
+            value = record[key]
+            # Some values have embedded \r... print literally
+            print(f"{key} === {repr(value)}")
+        print("")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-# # For MARC records
-# pymarc==5.1.2 
-# alma_api_client must be installed from the GitHub repository
+# alma_api_client must be installed from the GitHub repository.
+# This also brings in pymarc, for MARC records.
 git+https://github.com/UCLALibrary/alma-api-client
 # For Excel conversion
 pandas==2.2.3
@@ -8,3 +7,5 @@ pandas==2.2.3
 spacy==3.7.5
 en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
 en_core_web_md @ https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.7.1/en_core_web_md-3.7.1-py3-none-any.whl
+# For Filemaker API access
+python-fmrest==1.7.5


### PR DESCRIPTION
Implements [SYS-1741](https://uclalibrary.atlassian.net/browse/SYS-1741).

This PR adds a simple script to confirm Filemaker API access is working. It connects, does a search to retrieve a record, and dumps all data for that record.  A second search, which finds multiple records, is commented out but behaves exactly the same way.

Testing: At this point, just confirm the image builds and that your personal Filemaker credentials work.  Necessary info should be in the updated `README.md`, but included below as well.

* Rebuild container: `docker compose build`
* Update your local config file by adding the following, filling in your user-specific Filemaker username and password:
```
[filemaker]
api_version="vLatest"
database="Inventory for Labeling"
layout="InventoryForLabeling_ReadOnly_API"
password="YOUR_PASSWORD"
url = "https://adam.cinema.ucla.edu"
user="YOUR_NAME"
```
* Run: `docker compose run ftva_data python filemaker_api_test.py --config_file prod_config_secrets.toml` (or whatever your config file is called)

Output should look like this:
```
===== Data for record number 1 =====
<Foundset consumed_records=0 is_complete=False>
additional_physical_description === ''
aperture === ''
availability === 'ARCHIVAL COPY'
can === 1
collection === ''
collection_title === ''

[ ... long list of fields skipped ]

ALIAS === 'N/A'
GATOR === 'N/A'
incomplete_holding === ''
recordId === '82931'
modId === '108'
portal_Labeling Database_InvID === <Foundset consumed_records=0 is_complete=False>
```

The literal `<Foundset consumed_records=0 is_complete=False>` comes from the API client package. I haven't found how to suppress this yet.


[SYS-1741]: https://uclalibrary.atlassian.net/browse/SYS-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ