### PR TITLE
SYS-1783: Add script to extract inventory numbers from FTVA spreadsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,9 @@ This script extracts duplicate rows from the Tapes tab of the FTVA spreadsheet b
 If `--tapes_tab_name` is specified, the script will look for the tab with that name within the spreadsheet. Otherwise, it will look for a tab named "Tapes(row 4560-24712)".
 
 If `--remove_duplicates` is specified, the script will remove the duplicate rows from the original spreadsheet and save it in place. Otherwise the original spreadsheet will not be modified.
+
+### Extract inventory numbers from FTVA spreadsheet
+
+```python extract_inventory_numbers.py --data_file SPREADSHEET.xlsx```
+
+This script extracts inventory numbers from the values of the "Legacy Path" column in the Tapes tab of the FTVA spreadsheet. The script generates a copy of the input spreadsheet with a column appended named `Inventory Number [EXTRACTED]`, with matched inventory numbers. The copy is saved with the name `SPREADSHEET_with_inventory_numbers.xlsx` in the same directory as the input spreadsheet.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,13 @@ user="YOUR_NAME"
 ### Proof of concept for Filemaker API (find and display data)
 
 ```python filemaker_api_test.py [-h] --config_file CONFIG_FILE```
+
+### Extract duplicate rows from FTVA spreadsheet
+
+```python extract_duplicate_rows.py --data_file SPREADSHEET.xlsx [--tapes_tab_name TAB_NAME] [--output_duplicate_path OUTPUT_PATH.xlsx] [--remove_duplicates]```
+
+This script extracts duplicate rows from the Tapes tab of the FTVA spreadsheet based on the "Legacy Path" column. Duplicate rows will be saved to the file specified by `--output_duplicate_path` (defaults to `duplicate_rows.xlsx` in the current directory).
+
+If `--tapes_tab_name` is specified, the script will look for the tab with that name within the spreadsheet. Otherwise, it will look for a tab named "Tapes(row 4560-24712)".
+
+If `--remove_duplicates` is specified, the script will remove the duplicate rows from the original spreadsheet and save it in place. Otherwise the original spreadsheet will not be modified.

--- a/extract_duplicate_rows.py
+++ b/extract_duplicate_rows.py
@@ -1,0 +1,117 @@
+import argparse
+import pandas as pd
+from pathlib import Path
+
+
+def _get_args() -> argparse.Namespace:
+    """Returns the command-line arguments for this program."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--data_file",
+        help="Path to XLSX spreadsheet provided by FTVA",
+        required=True,
+    )
+    parser.add_argument(
+        "--tapes_tab_name",
+        help="Name of the spreadsheet tab containing tape data",
+        default="Tapes(row 4560-24712)",
+    )
+    parser.add_argument(
+        "--output_duplicate_path",
+        help="Path to the output spreadsheet for duplicate rows",
+        default="duplicate_rows.xlsx",
+    )
+    parser.add_argument(
+        "--remove_duplicates",
+        help="If specified, remove duplicate rows from the spreadsheet in place",
+        action="store_true",
+    )
+    args = parser.parse_args()
+    return args
+
+
+def _find_duplicate_rows(df: pd.DataFrame) -> pd.DataFrame:
+    """Find duplicate rows in the DataFrame based on the 'Legacy Path' column."""
+    # Check if 'Legacy Path' column exists
+    if "Legacy Path" not in df.columns:
+        raise ValueError("The DataFrame does not contain a 'Legacy Path' column.")
+
+    # Find duplicate rows based on the 'Legacy Path' column
+    duplicate_rows = df[df.duplicated(subset=["Legacy Path"], keep=False)]
+
+    return duplicate_rows
+
+
+def _format_duplicate_rows(duplicate_rows: pd.DataFrame) -> pd.DataFrame:
+    """Format duplicate rows for better readability in an output spreadsheet."""
+    # Create a copy of the DataFrame to avoid modifying the original slice,
+    # which causes pandas to raise a SettingWithCopyWarning
+    duplicate_rows = duplicate_rows.copy()
+    # Add a new column with the original row index
+    duplicate_rows.reset_index(inplace=True, names="Original Row Number")
+    # increment each index by 2 to match the original spreadsheet
+    # (1 based index, plus header row)
+    duplicate_rows["Original Row Number"] += 2
+
+    return duplicate_rows
+
+
+def _remove_duplicates_from_df(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove duplicate rows from the DataFrame."""
+    # Remove duplicates based on 'Legacy Path' column, keeping the first occurrence
+    # and dropping the rest
+    df.drop_duplicates(subset=["Legacy Path"], keep="first", inplace=True)
+    return df
+
+
+def _remove_duplicates_from_spreadsheet(
+    df: pd.DataFrame, data_file_path: Path, tapes_tab_name: str
+) -> None:
+    """Remove duplicate rows from the DataFrame and save it back to the spreadsheet."""
+    # Remove duplicates from the DataFrame
+    df = _remove_duplicates_from_df(df)
+    # Save the cleaned DataFrame back to the spreadsheet;
+    # only overwrite the specified tab, and keep the rest of the spreadsheet intact
+    with pd.ExcelWriter(
+        data_file_path, engine="openpyxl", mode="a", if_sheet_exists="replace"
+    ) as writer:
+        df.to_excel(writer, sheet_name=tapes_tab_name, index=False)
+    print(f"Duplicate rows removed. Updated spreadsheet saved to {data_file_path}.")
+
+
+def main():
+    args = _get_args()
+    data_file_path = Path(args.data_file)
+
+    if not data_file_path.exists():
+        raise FileExistsError("Data file does not exist")
+
+    # check that tab exists within the spreadsheet
+    xls = pd.ExcelFile(data_file_path)
+    if args.tapes_tab_name not in xls.sheet_names:
+        raise ValueError(
+            f"Tab '{args.tapes_tab_name}' does not exist in the spreadsheet"
+        )
+
+    # Read the spreadsheet into a DataFrame
+    df = pd.read_excel(data_file_path, sheet_name=args.tapes_tab_name)
+    print(f"Data loaded from {data_file_path}, tab: {args.tapes_tab_name}.")
+
+    # Find duplicate rows
+    duplicate_rows = _find_duplicate_rows(df)
+    if duplicate_rows.empty:
+        print("No duplicate rows found.")
+    else:
+        print(f"{len(duplicate_rows)} duplicate rows found.")
+        duplicate_rows = _format_duplicate_rows(duplicate_rows)
+        duplicate_rows_path = Path(args.output_duplicate_path)
+        duplicate_rows.to_excel(duplicate_rows_path, index=False)
+        print(f"Duplicate rows saved to {duplicate_rows_path}.")
+
+        # Optionally, remove duplicates
+        if args.remove_duplicates:
+            _remove_duplicates_from_spreadsheet(df, data_file_path, args.tapes_tab_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/extract_inventory_numbers.py
+++ b/extract_inventory_numbers.py
@@ -19,10 +19,16 @@ def _get_args() -> argparse.Namespace:
 def _compile_regex() -> re.Pattern:
     # Return a compiled RegEx pattern for matching inventory numbers
     # the RegEx is comprised of three main parts, which are explained inline below
+    #
+    # NOTE: the pattern works in most cases, but will return false positives
+    # where the input contains a substring that syntactically matches pattern
+    # but is not actually a valid inventory number, according to FTVA
+    # e.g. AAC442\Title_T01ASYNC_Surround matches T01, which is a valid pattern,
+    # but not an actual inventory number
     regex_components = [
         r'(?<![A-Z])',  # pattern not preceded by capital letter, to mitigate false positives
         r'(?:M|T|DVD|FE|HFA|VA|XFE|XFF|XVE)',  # non-capturing group of 8 prefixes defined by FTVA
-        r'\d+',  # 1 or more digits, as many as possible
+        r'\d{2,}',  # 2 or more digits, as many as possible
         r'(?:[A-Z](?![A-Za-z]))?'  # optional suffix 1 capital letter not followed by another letter
     ]
 
@@ -41,7 +47,10 @@ def _extract_inventory_numbers(
     if matches:
         # per FTVA spec, provide pipe-delimited string
         # if multiple matches in a single input value
-        return '|'.join(set(matches))  # using set() to provide only unique inv #s
+        # uses dict.fromkeys() to get unique values
+        # while maintaining list order
+        return '|'.join(list(dict.fromkeys(matches)))
+    return ''
 
 
 def main() -> None:

--- a/extract_inventory_numbers.py
+++ b/extract_inventory_numbers.py
@@ -3,10 +3,6 @@ import re
 import pandas as pd
 from pathlib import Path
 
-# Regular expression to match inventory numbers,
-# per FTVA specification
-INVENTORY_NUMBER_PATTERN = re.compile(r'(?:M|T|DVD|HFA|VA|XFE|XFF|XVE)\d+(?:[A-Z](?![A-Za-z]))?')
-
 
 def _get_args() -> argparse.Namespace:
     """Returns the command-line arguments for this program."""
@@ -20,22 +16,49 @@ def _get_args() -> argparse.Namespace:
     return args
 
 
+def _compile_regex() -> re.Pattern:
+    # Return a compiled RegEx pattern for matching inventory numbers
+    # the RegEx is comprised of three main parts, which are explained inline below
+    regex_components = [
+        r'(?:M|T|DVD|HFA|VA|XFE|XFF|XVE)',  # non-capturing group of 8 prefixes defined by FTVA
+        r'\d+',  # 1 or more digits, as many as possible
+        r'(?:[A-Z](?![A-Za-z]))?'  # optional suffix 1 capital letter not followed by another letter
+    ]
+
+    return re.compile(''.join(regex_components))
+
+
 def _extract_inventory_numbers(df: pd.DataFrame) -> pd.DataFrame:
+
+    inventory_number_pattern = _compile_regex()
+
     # Priority in which to consider columns,
     # per instructions from FTVA
     column_priority = ('Source Inventory #', 'File Name', 'Sub Folder', 'File Folder Name')
+    existing_inventory_number_values = []
 
     for index, row in df.iterrows():
+        # The header row in the source spreadsheet is repeated many times
+        # as if multiple sheets were appended together
+        # this condition checks if the current value in the Inventory # column is:
+        # 1) not a header, and;
+        # 2) not NaN
+        # meaning it is some other value
+        # row indexes for any such values are then appended to a list to be printed for reference
+        if (not row['Inventory #'] == 'Inventory #') and (not pd.isna(row['Inventory #'])):
+            existing_inventory_number_values.append(index)
+
         for column in column_priority:
             if not isinstance(row[column], str):
                 continue
 
-            matches = re.findall(INVENTORY_NUMBER_PATTERN, row[column])
+            matches = re.findall(inventory_number_pattern, row[column])
             if matches:
                 # per FTVA spec, provide pipe-delimited string
                 # if multiple matches in a single input value
                 row['Inventory #'] = '|'.join(matches)
                 break  # we only want the first match in a row
+    print(df.iloc[existing_inventory_number_values]['Inventory #'])
     return df
 
 

--- a/extract_inventory_numbers.py
+++ b/extract_inventory_numbers.py
@@ -1,0 +1,59 @@
+import argparse
+import re
+import pandas as pd
+from pathlib import Path
+
+# Regular expression to match inventory numbers,
+# per FTVA specification
+INVENTORY_NUMBER_PATTERN = re.compile(r'(?:M|T|DVD|HFA|VA|XFE|XFF|XVE)\d+(?:[A-Z](?![A-Za-z]))?')
+
+
+def _get_args() -> argparse.Namespace:
+    """Returns the command-line arguments for this program."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--data_file",
+        help="Path to XLSX spreadsheet provided by FTVA",
+        required=True,
+    )
+    args = parser.parse_args()
+    return args
+
+
+def _extract_inventory_numbers(df: pd.DataFrame) -> pd.DataFrame:
+    # Priority in which to consider columns,
+    # per instructions from FTVA
+    column_priority = ('Source Inventory #', 'File Name', 'Sub Folder', 'File Folder Name')
+
+    for index, row in df.iterrows():
+        for column in column_priority:
+            if not isinstance(row[column], str):
+                continue
+
+            matches = re.findall(INVENTORY_NUMBER_PATTERN, row[column])
+            if matches:
+                # per FTVA spec, provide pipe-delimited string
+                # if multiple matches in a single input value
+                row['Inventory #'] = '|'.join(matches)
+                break  # we only want the first match in a row
+    return df
+
+
+def main() -> None:
+    """Extracts inventory numbers from values in a spreadsheet provided by FTVA digital lab."""
+    args = _get_args()
+
+    input_file_path = Path(args.data_file)
+    if not input_file_path.exists():
+        raise FileExistsError("Data file does not exist")
+
+    df = pd.read_excel(args.data_file, sheet_name='Source Data', header=1)
+    df_with_inventory_numbers = _extract_inventory_numbers(df)
+
+    # Save new XLSX file with extracted inventory numbers
+    output_path = Path(args.data_file).with_stem(input_file_path.stem + "_with_inventory_numbers")
+    df_with_inventory_numbers.to_excel(output_path, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/extract_inventory_numbers.py
+++ b/extract_inventory_numbers.py
@@ -45,11 +45,23 @@ def _extract_inventory_numbers(
 
     matches = re.findall(inventory_number_pattern, value)
     if matches:
-        # per FTVA spec, provide pipe-delimited string
-        # if multiple matches in a single input value
         # uses dict.fromkeys() to get unique values
         # while maintaining list order
-        return '|'.join(list(dict.fromkeys(matches)))
+        unique_inventory_numbers = list(dict.fromkeys(matches))
+
+        # NOTE: hard-coding a list of known false positives here
+        # i.e. strings that match pattern but are known to not be actual inv #s
+        # this could be made into a script argument later
+        #
+        # if such values exist in list of unique inv #s, remove them
+        known_false_positives = ["T01"]
+        for false_positive in known_false_positives:
+            if false_positive in unique_inventory_numbers:
+                unique_inventory_numbers.remove(false_positive)
+
+        # per FTVA spec, provide pipe-delimited string
+        # if multiple matches in a single input value
+        return '|'.join(unique_inventory_numbers)
     return ''
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 git+https://github.com/UCLALibrary/alma-api-client
 # For Excel conversion
 pandas==2.2.3
+openpyxl==3.1.5
 # for NLP
 spacy==3.7.5
 en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl

--- a/tests/test_extract_duplicate_rows.py
+++ b/tests/test_extract_duplicate_rows.py
@@ -1,0 +1,101 @@
+import unittest
+from extract_duplicate_rows import (
+    _find_duplicate_rows,
+    _format_duplicate_rows,
+    _remove_duplicates_from_df,
+)
+import pandas as pd
+
+
+class TestFormatDuplicateRows(unittest.TestCase):
+
+    def setUp(self):
+        self.df = pd.DataFrame(
+            {
+                "Legacy Path": [
+                    "path/to/file1",
+                    "path/to/file1",  # Duplicate
+                    "path/to/file2",
+                    "path/to/file3",
+                    "path/to/file3",  # Duplicate
+                ],
+                "Other Column": [1, 2, 3, 4, 5],
+            }
+        )
+
+    def test_format_duplicate_rows(self):
+        duplicate_rows = _find_duplicate_rows(self.df)
+        formatted_rows = _format_duplicate_rows(duplicate_rows)
+        expected_output = pd.DataFrame(
+            {
+                # "Original Row Number" is the index of the original DataFrame + 2
+                # to account for 1-based indexing and the header row
+                "Original Row Number": [2, 3, 5, 6],
+                "Legacy Path": [
+                    "path/to/file1",
+                    "path/to/file1",
+                    "path/to/file3",
+                    "path/to/file3",
+                ],
+                "Other Column": [1, 2, 4, 5],
+            }
+        )
+        pd.testing.assert_frame_equal(formatted_rows, expected_output)
+
+    def test_format_duplicate_rows_no_duplicates(self):
+        # Test with a DataFrame that has no duplicates
+        no_duplicates_df = pd.DataFrame(
+            {
+                "Legacy Path": ["path/to/file1", "path/to/file2", "path/to/file3"],
+                "Other Column": [1, 2, 3],
+            }
+        )
+        no_duplicates_df = _find_duplicate_rows(no_duplicates_df)
+        formatted_rows = _format_duplicate_rows(no_duplicates_df)
+        self.assertTrue(formatted_rows.empty)
+        self.assertIn("Original Row Number", formatted_rows.columns)
+
+
+class TestRemoveDuplicatesFromDf(unittest.TestCase):
+    def setUp(self):
+        self.df_with_duplicates = pd.DataFrame(
+            {
+                "Legacy Path": [
+                    "path/to/file1",
+                    "path/to/file2",
+                    "path/to/file1",  # Duplicate
+                    "path/to/file3",
+                    "path/to/file2",  # Duplicate
+                ],
+                "Other Column": [1, 2, 3, 4, 5],
+            }
+        )
+        self.df_without_duplicates = pd.DataFrame(
+            {
+                "Legacy Path": [
+                    "path/to/file1",
+                    "path/to/file2",
+                    "path/to/file3",
+                ],
+                "Other Column": [1, 2, 4],
+            }
+        )
+
+    def test_remove_duplicates_from_df(self):
+        cleaned_df = _remove_duplicates_from_df(self.df_with_duplicates)
+        expected_df = pd.DataFrame(
+            {
+                "Legacy Path": [
+                    "path/to/file1",
+                    "path/to/file2",
+                    "path/to/file3",
+                ],
+                "Other Column": [1, 2, 4],
+            },
+            index=[0, 1, 3],
+        )
+        pd.testing.assert_frame_equal(cleaned_df, expected_df)
+
+    def test_remove_duplicates_from_df_no_duplicates(self):
+        cleaned_df = _remove_duplicates_from_df(self.df_without_duplicates)
+        pd.testing.assert_frame_equal(cleaned_df, self.df_without_duplicates)

--- a/tests/test_extract_inventory_numbers.py
+++ b/tests/test_extract_inventory_numbers.py
@@ -1,6 +1,5 @@
 import unittest
-import re
-from extract_inventory_numbers import _compile_regex
+from extract_inventory_numbers import _extract_inventory_numbers
 
 
 class TestRegEx(unittest.TestCase):
@@ -30,10 +29,18 @@ class TestRegEx(unittest.TestCase):
             (
                 "M46293SanFernandoCLEANEXPORT3",
                 "M46293"
-            )  # contains valid inv # (M46293), but also look-alike (T3)
+            ),  # contains valid inv # (M46293), but also look-alike (T3)
+            # flake8 flagged escape seq (\T), hence raw strings in following cases
+            (
+                r"AAC424\T70123_50Years_Kids_Programming\T70123_50Years_T1",
+                "T70123"
+            ),  # per FTVA, inv #s have 2 or more digits, so T70123 is good, but T1 is invalid
+            (
+                r"AAC442\Title_T01ASYNC_Surround",
+                "T01"
+            )  # known false positive--T01 is syntactically valid, but not actual inv #, per FTVA
         )
 
-        inventory_number_pattern = _compile_regex()
         for input, output in test_cases:
-            matches = re.findall(inventory_number_pattern, input)
-            self.assertEqual('|'.join(matches), output)
+            inventory_numbers = _extract_inventory_numbers(input)
+            self.assertEqual(inventory_numbers, output)

--- a/tests/test_extract_inventory_numbers.py
+++ b/tests/test_extract_inventory_numbers.py
@@ -37,8 +37,9 @@ class TestRegEx(unittest.TestCase):
             ),  # per FTVA, inv #s have 2 or more digits, so T70123 is good, but T1 is invalid
             (
                 r"AAC442\Title_T01ASYNC_Surround",
-                "T01"
+                ""
             )  # known false positive--T01 is syntactically valid, but not actual inv #, per FTVA
+               # script should remove these
         )
 
         for input, output in test_cases:

--- a/tests/test_extract_inventory_numbers.py
+++ b/tests/test_extract_inventory_numbers.py
@@ -13,8 +13,10 @@ class TestRegEx(unittest.TestCase):
             ("HFA27M_Reel", "HFA27M"),
             ("VA13161T_KTLA", "VA13161T"),
             ("M190816Medea2", "M190816"),
+            ("DVD13360_HouseOfCats_FromDVD_SD_2997FPS_VOB", "DVD13360"),
+            ("GeraldMcBoingBoingShow_T119482_DerTeamfromZwisendorpff", "T119482"),
             ("XFE1915MX", "XFE1915"),  # invalid suffix case
-            ("Randy_Requiem1", ""),
+            ("Randy_Requiem1", ""),  # no matching inv # in this case, so should be empty string
             (
                 "XFE4098M_XFF104M_DamagedLives_Finals",
                 "XFE4098M|XFF104M"
@@ -22,7 +24,13 @@ class TestRegEx(unittest.TestCase):
             (
                 "XVE779T_ZVE780T_OneNightStand_WorldOfLennyBruce_CaptureFiles_SD_2997FPS_YUV",
                 "XVE779T"
-            )  # close-but-no-cigar case (ZVE780T does not have valid prefix)
+            ),  # XVE is a valid prefix, but ZVE isn't, so only 1 valid inv # in input
+            ("Max_From_DVD_H264", ""),  # input has pattern look-alike (H264), but no valid inv #
+            ("HARVEST3000AUDIOMAG", ""),  # like last case, look-alike in middle, but no valid inv #
+            (
+                "M46293SanFernandoCLEANEXPORT3",
+                "M46293"
+            )  # contains valid inv # (M46293), but also look-alike (T3)
         )
 
         inventory_number_pattern = _compile_regex()

--- a/tests/test_extract_inventory_numbers.py
+++ b/tests/test_extract_inventory_numbers.py
@@ -1,0 +1,31 @@
+import unittest
+import re
+from extract_inventory_numbers import _compile_regex
+
+
+class TestRegEx(unittest.TestCase):
+
+    def test_regex(self):
+        # test cases comprised of tuples
+        # where the first item is the input string
+        # and the second item is the expected output derived from FTVA specs
+        test_cases = (
+            ("HFA27M_Reel", "HFA27M"),
+            ("VA13161T_KTLA", "VA13161T"),
+            ("M190816Medea2", "M190816"),
+            ("XFE1915MX", "XFE1915"),  # invalid suffix case
+            ("Randy_Requiem1", ""),
+            (
+                "XFE4098M_XFF104M_DamagedLives_Finals",
+                "XFE4098M|XFF104M"
+            ),  # multi-match to pipe-delimited string case
+            (
+                "XVE779T_ZVE780T_OneNightStand_WorldOfLennyBruce_CaptureFiles_SD_2997FPS_YUV",
+                "XVE779T"
+            )  # close-but-no-cigar case (ZVE780T does not have valid prefix)
+        )
+
+        inventory_number_pattern = _compile_regex()
+        for input, output in test_cases:
+            matches = re.findall(inventory_number_pattern, input)
+            self.assertEqual('|'.join(matches), output)


### PR DESCRIPTION
Implements [SYS-1783](https://uclalibrary.atlassian.net/browse/SYS-1783)

**Summary**
- Loads data from FTVA digital lab spreadsheet
- Matches values against inventory number pattern described by FTVA staff
  - Only outputs first match according to specified column priority
  - If multiple matches in a single input string, outputs pipe-delimited list
- Writes new Excel spreadsheet with extracted inventory numbers in the `Inventory #` column

**Testing**
I used [regex101](https://regex101.com/) to assemble and test the regular expression I used. I also wrote a short test for the regular expression using `pytest` locally, but since `pytest` isn't an existing requirement for the dev container, I didn't bother including that test in this PR.

**Running script**
From within the dev container, run: `python extract_inventory_numbers.py --data_file ${PATH_TO_DL_SPREADSHEET}`

**Note**
You may need to install the `openpyxl` package, as `pandas` uses it for reading and writing to Excel formats.

[SYS-1783]: https://uclalibrary.atlassian.net/browse/SYS-1783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ