### PR TITLE
SYS-1875: Report on single / perfect matches

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,32 +1,24 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
-	"image": "ftva-mams-data-ftva_data:latest",
+	"name": "FTVA MAMS Data",
+	"dockerComposeFile": "../docker-compose.yml",
+	"service": "ftva_data",
+	"workspaceFolder": "/home/ftva_data/project",
 	"customizations": {
-		"vscode": {
-			"extensions": [
-				"ms-python.python",
-				"ms-python.black-formatter",
-				"ms-python.flake8"
-			]
-		}
-	},
-	"workspaceMount": "source=${localWorkspaceFolder},target=/home/ftva_data/project,type=bind",
-	"workspaceFolder": "/home/ftva_data/project"
-
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Uncomment the next line to run commands after the container is created.
-	// "postCreateCommand": "cat /etc/os-release",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "devcontainer"
+			"vscode": {
+					"extensions": [
+							"ms-python.python",
+							"ms-python.black-formatter",
+							"ms-python.flake8"
+					],
+					"settings": {
+							"editor.formatOnSave": true,
+							"python.analysis.typeCheckingMode": "standard",
+							"python.editor.defaultFormatter": "ms-python.black-formatter",
+					"flake8.args": [
+									"--max-line-length=100",
+									"--extend-ignore=E203"
+							]
+					}
+			}
+	}
 }

--- a/README.md
+++ b/README.md
@@ -37,18 +37,21 @@ Running code from a VS Code terminal within the dev container should just work, 
 Otherwise, run a program via docker compose.  From the project directory:
 
 ```
+# Start the system
+$ docker compose up -d
+
 # Open a shell in the container
-$ docker compose run ftva_data bash
+$ docker compose exec ftva_data bash
 
 # Open a Python shell in the container
-$ docker compose run ftva_data python
+$ docker compose exec ftva_data python
 ```
 
 ### Running tests
 
 Several scripts have tests.  To run tests:
 ```
-$ docker compose run ftva_data python -m unittest
+$ docker compose exec ftva_data python -m unittest
 ```
 
 ### Secrets
@@ -74,8 +77,8 @@ user="YOUR_NAME"
 ## Scripts
 
 Examples below assume you're running them in an existing `bash` shell within the container.  To run from outside, launching
-a container, add `docker compose run ftva_data ` to the beginning of the command (e.g., 
-`docker compose run ftva_data python filemaker_get_all_records.py --config_file CONFIG_FILE` ).
+a container, add `docker compose exec ftva_data ` to the beginning of the command (e.g., 
+`docker compose exec ftva_data python filemaker_get_all_records.py --config_file CONFIG_FILE` ).
 
 ### Retrieve all Filemaker records
 

--- a/README.md
+++ b/README.md
@@ -160,3 +160,29 @@ len(each_to_one_fm_or_alma)=167
 len(at_least_one_to_mult_fm_or_alma)=28
 len(leftovers)=224
 ```
+
+### Report "perfect" inventory number matches across multiple data sources
+
+```
+python get_perfect_matches.py \
+     --alma_data_file FTVA_HOLDINGS.csv \
+     --dl_data_file DL_DATA.json \
+     --filemaker_data_file FILEMAKER_DATA.json \
+     --output_file REPORT_FILE.xlsx
+```
+
+This is similar to `report_inventory_number_matches.py`, but reports only on "perfect" (1-1-1)
+matches between Alma holdings, Filemaker, and data exported from the Digital Labs Django application.
+These matches mean the inventory number occurs only once in each source, and matches exactly across
+all sources.
+
+Output looks like this (counts will vary):
+```
+Read 368324 records from ftva_holdings_20250624.csv
+Alma data: 256458 rows
+Read 26924 records from dl_data.json
+DL data: 4520 rows
+Read 605353 records from filemaker_data_20250624_182542.json
+FM data: 553605 rows
+Found 2177 perfect matches.
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,5 @@ services:
     # tty: true
     volumes: 
       - .:/home/ftva_data/project
+    # Keep the container running until stopped via docker compose.
+    command: "sleep infinity"

--- a/get_perfect_matches.py
+++ b/get_perfect_matches.py
@@ -1,0 +1,142 @@
+import argparse
+import csv
+import json
+import pandas as pd
+
+
+def _get_alma_data(filename: str) -> dict:
+    with open(filename, "r") as f:
+        data = csv.DictReader(f)
+        data = [row for row in data]
+    print(f"Read {len(data)} records from {filename}")
+
+    alma_data = {}
+    for row in data:
+        # Many Alma values have spaces; remove them;
+        # also force to upper case.
+        inventory_no: str = row["Permanent Call Number"].replace(" ", "").upper()
+        # Keep only unique (after normalizing) inventory numbers, and their
+        # full row of data for use later.
+        if inventory_no not in alma_data:
+            alma_data[inventory_no] = row
+
+    return alma_data
+
+
+def _get_dl_data(filename: str) -> dict:
+    with open(filename, "r") as f:
+        data = json.load(f)
+    print(f"Read {len(data)} records from {filename}")
+
+    dl_data = {}
+    for row in data:
+        # DL data exported as a Django fixture has model (ignore), pk (id),
+        # and fields (dict of all other field names and values).
+        # Combine these for later use.
+        field_data = row["fields"]
+        field_data["pk"] = row["pk"]
+        # DL inventory numbers were previously normalized at the source;
+        # we don't care if they're compound or invalid, as those won't match
+        # Alma or Filemaker data anyhow.
+        inventory_no: str = field_data["inventory_number"]
+        # Keep only unique (after normalizing) inventory numbers, and their
+        # full row of data for use later.
+        if inventory_no not in dl_data:
+            dl_data[inventory_no] = field_data
+
+    return dl_data
+
+
+def _get_filemaker_data(filename: str) -> dict:
+    with open(filename, "r") as f:
+        data = json.load(f)
+    print(f"Read {len(data)} records from {filename}")
+
+    filemaker_data = {}
+    for row in data:
+        # Some Filemaker inventory numbers end with (or in 1 case, contain)
+        # u'\xa0', non-breaking space.  Almost certainly errors; remove this character.
+        # Also force to upper case.
+        inventory_no: str = row["inventory_no"].replace("\xa0", "").upper()
+        # Keep only unique (after normalizing) inventory numbers, and their
+        # full row of data for use later.
+        if inventory_no not in filemaker_data:
+            filemaker_data[inventory_no] = row
+
+    return filemaker_data
+
+
+def _get_args() -> argparse.Namespace:
+    """Returns the command-line arguments for this program."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--alma_data_file",
+        help="Path to CSV file containing FTVA Alma holdings data",
+        required=True,
+    )
+    parser.add_argument(
+        "--dl_data_file",
+        help="Path to JSON file containing FTVA Digital (formerly Google Sheets) data",
+        required=True,
+    )
+    parser.add_argument(
+        "--filemaker_data_file",
+        help="Path to JSON file containing FTVA Filemaker data",
+        required=True,
+    )
+    parser.add_argument(
+        "--output_file",
+        help="Path to XLSX output file which will be written to",
+        required=True,
+    )
+    args = parser.parse_args()
+    return args
+
+
+def main() -> None:
+    args = _get_args()
+
+    alma_data = _get_alma_data(args.alma_data_file)
+    print(f"Alma data: {len(alma_data)} rows")
+
+    dl_data = _get_dl_data(args.dl_data_file)
+    print(f"DL data: {len(dl_data)} rows")
+
+    filemaker_data = _get_filemaker_data(args.filemaker_data_file)
+    print(f"FM data: {len(filemaker_data)} rows")
+
+    # We only want the "perfect" matches, where the inventory number
+    # occurs in all dictionaries.
+    # Convert keys to sets and find the intersection; sort keys for better output.
+    perfect_matches = sorted(set(alma_data) & set(filemaker_data) & set(dl_data))
+    print(f"Found {len(perfect_matches)} perfect matches.")
+
+    # Get selected data from the sources for each matched inventory number.
+    output_data = []
+    for inventory_number in perfect_matches:
+        merged_data = {
+            "inventory_number": inventory_number,
+            "alma_holdings_id": alma_data[inventory_number].get("Holding Id", ""),
+            "fm_inventory_id": filemaker_data[inventory_number].get("inventory_id", ""),
+            "dl_record_id": dl_data[inventory_number].get("pk", ""),
+            "fm_title": filemaker_data[inventory_number].get("title", ""),
+            "dl_carrier_a": dl_data[inventory_number].get("carrier_a", ""),
+            "dl_carrier_a_loc": dl_data[inventory_number].get("carrier_a_location", ""),
+            "dl_carrier_b": dl_data[inventory_number].get("carrier_b", ""),
+            "dl_carrier_b_loc": dl_data[inventory_number].get("carrier_b_location", ""),
+            "dl_hard_drive_name": dl_data[inventory_number].get("hard_drive_name", ""),
+            "dl_file_folder_name": dl_data[inventory_number].get(
+                "file_folder_name", ""
+            ),
+            "dl_sub_folder_name": dl_data[inventory_number].get("sub_folder_name", ""),
+            "dl_file_name": dl_data[inventory_number].get("file_name", ""),
+        }
+        output_data.append(merged_data)
+
+    df = pd.DataFrame(output_data)
+    with pd.ExcelWriter(args.output_file) as writer:
+        df.to_excel(writer, index=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements [SYS-1875](https://uclalibrary.atlassian.net/browse/SYS-1875).  Note that this is the utilities `ftva-mams-data` repository, not the Django `ftva-labs-data`.

This PR adds a script, `get_perfect_matches.py`, which reports only on "perfect" (1-1-1) matches between Alma holdings, Filemaker, and data exported from the Digital Labs Django application.  These matches mean the inventory number occurs only once in each source, and matches exactly across all sources.  The script is documented in `README.md`.

It also tweaks the development environment:
* `.devcontainer/devcontainer.json` now uses the local `docker-compose.yml` instead of a hard-coded image name.  It also moves required tool configuration (linting, type-checking) into the container, consistent with our new approach.
* `docker-compose.yml` now runs a `sleep infinity` command, so the container continues running.  This is needed to support the `docker compose` integration with `devcontainer.json`.
* `README.md` is updated to reflect that commands are run now with `docker compose exec` (since the container is running) instead of `docker compose run`.

### Testing

No automated tests for this, as the data manipulation and matching is very simple.

If you want to run it locally, you'll need 3 data files
* Alma holdings: via `get_ftva_holdings_report.py`, see `README.md` for more info
* Filemaker data: via `filemaker_get_all_records.py`, see `README.md` for more info
* DL data exported from Django.  In that local system, with recent/current data loaded and fully cleaned, run
```docker compose exec django python manage.py dumpdata ftva_lab_data.SheetImport --indent 2 --output dl_data.json```
then copy `dl_data.json` to this project directory and run the `get_perfect_matches.py` command as documented in the README.



[SYS-1875]: https://uclalibrary.atlassian.net/browse/SYS-1875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ