### PR TITLE
SYS-1886: Fix uniqueness bug in get_perfect_matches

### DIFF
--- a/get_perfect_matches.py
+++ b/get_perfect_matches.py
@@ -105,6 +105,13 @@ def _get_filemaker_data(filename: str) -> dict:
 
 
 def _get_singletons(data: list[dict]) -> set[str]:
+    """Given a list of dictionaries, with each having an `inventory_number` key,
+    returns the inventory number values which occur only once throughout the list.
+
+    :param data: A list of dictionaries.
+    :return singletons: A set of inventory number values which occur only once in `data`.
+    :raises KeyError: if any dictionary does not have an `inventory_number` key.
+    """
     # Get number of times each inventory number occurs.
     counts = Counter([row["inventory_number"] for row in data])
     # Uniqueness guaranteed by count == 1, but use set for much faster lookups in next step.

--- a/get_perfect_matches.py
+++ b/get_perfect_matches.py
@@ -2,6 +2,7 @@ import argparse
 import csv
 import json
 import pandas as pd
+from collections import Counter
 
 
 def _get_alma_data(filename: str) -> dict:
@@ -18,15 +19,20 @@ def _get_alma_data(filename: str) -> dict:
         data = [row for row in data]
     print(f"Read {len(data)} records from {filename}")
 
-    alma_data = {}
+    # Clean up & normalize Alma-specific inventory numbers.
     for row in data:
         # Many Alma values have spaces; remove them;
         # also force to upper case.
-        inventory_no: str = row["Permanent Call Number"].replace(" ", "").upper()
-        # Keep only unique (after normalizing) inventory numbers, and their
-        # full row of data for use later.
-        if inventory_no not in alma_data:
-            alma_data[inventory_no] = row
+        row["inventory_number"] = row["Permanent Call Number"].replace(" ", "").upper()
+
+    singletons = _get_singletons(data)
+
+    # Get the data just for rows which have a unique inventory number.
+    alma_data = {
+        row["inventory_number"]: row
+        for row in data
+        if row["inventory_number"] in singletons
+    }
 
     return alma_data
 
@@ -41,24 +47,26 @@ def _get_dl_data(filename: str) -> dict:
     row of data as the value.
     """
     with open(filename, "r") as f:
-        data = json.load(f)
+        data: list[dict] = json.load(f)
     print(f"Read {len(data)} records from {filename}")
 
-    dl_data = {}
+    # DL data exported as a Django fixture has model (ignored here), pk (id),
+    # and fields (dict of all other field names and values).
+    # Combine these for later use.
+    field_data: list[dict] = []
     for row in data:
-        # DL data exported as a Django fixture has model (ignored here), pk (id),
-        # and fields (dict of all other field names and values).
-        # Combine these for later use.
-        field_data = row["fields"]
-        field_data["pk"] = row["pk"]
-        # DL inventory numbers were previously normalized at the source;
-        # we don't care if they're compound or invalid, as those won't match
-        # Alma or Filemaker data anyhow.
-        inventory_no: str = field_data["inventory_number"]
-        # Keep only unique (after normalizing) inventory numbers, and their
-        # full row of data for use later.
-        if inventory_no not in dl_data:
-            dl_data[inventory_no] = field_data
+        tmp_data: dict = row["fields"]
+        tmp_data["pk"] = row["pk"]
+        field_data.append(tmp_data)
+
+    singletons = _get_singletons(field_data)
+
+    # Get the data just for rows which have a unique inventory number.
+    dl_data = {
+        row["inventory_number"]: row
+        for row in field_data
+        if row["inventory_number"] in singletons
+    }
 
     return dl_data
 
@@ -73,21 +81,37 @@ def _get_filemaker_data(filename: str) -> dict:
     row of data as the value.
     """
     with open(filename, "r") as f:
-        data = json.load(f)
+        data: list[dict] = json.load(f)
     print(f"Read {len(data)} records from {filename}")
 
-    filemaker_data = {}
+    # Clean up & normalize Filemaker-specific inventory numbers.
     for row in data:
-        # Some Filemaker inventory numbers end with (or in 1 case, contain)
+        # Some Filemaker inventory numbers end with (or contain)
         # u'\xa0', non-breaking space.  Almost certainly errors; remove this character.
-        # Also force to upper case.
-        inventory_no: str = row["inventory_no"].replace("\xa0", "").upper()
-        # Keep only unique (after normalizing) inventory numbers, and their
-        # full row of data for use later.
-        if inventory_no not in filemaker_data:
-            filemaker_data[inventory_no] = row
+        # Also force to upper case, and rename to inventory_number for consistency
+        # with other data sources.
+        row["inventory_number"] = row.pop("inventory_no").replace("\xa0", "").upper()
+
+    singletons = _get_singletons(data)
+
+    # Get the data just for rows which have a unique inventory number.
+    filemaker_data = {
+        row["inventory_number"]: row
+        for row in data
+        if row["inventory_number"] in singletons
+    }
 
     return filemaker_data
+
+
+def _get_singletons(data: list[dict]) -> set[str]:
+    # Get number of times each inventory number occurs.
+    counts = Counter([row["inventory_number"] for row in data])
+    # Uniqueness guaranteed by count == 1, but use set for much faster lookups in next step.
+    singletons = {
+        inventory_number for inventory_number, count in counts.items() if count == 1
+    }
+    return singletons
 
 
 def _get_args() -> argparse.Namespace:
@@ -121,13 +145,13 @@ def main() -> None:
     args = _get_args()
 
     alma_data = _get_alma_data(args.alma_data_file)
-    print(f"Alma data: {len(alma_data)} rows")
+    print(f"Alma singletons: {len(alma_data)} rows")
 
     dl_data = _get_dl_data(args.dl_data_file)
-    print(f"DL data: {len(dl_data)} rows")
+    print(f"DL singletons: {len(dl_data)} rows")
 
     filemaker_data = _get_filemaker_data(args.filemaker_data_file)
-    print(f"FM data: {len(filemaker_data)} rows")
+    print(f"FM singletons: {len(filemaker_data)} rows")
 
     # We only want the "perfect" matches, where the inventory number
     # occurs in all dictionaries.

--- a/tests/test_get_perfect_matches.py
+++ b/tests/test_get_perfect_matches.py
@@ -1,0 +1,25 @@
+import unittest
+from get_perfect_matches import _get_singletons
+
+
+class TestSingletons(unittest.TestCase):
+    def setUp(self):
+        self.sample_data: list[dict] = [
+            {"inventory_number": "123", "other_fields": "record 1"},
+            {"inventory_number": "456", "other_fields": "record 2"},
+            {"inventory_number": "789", "other_fields": "record 3"},
+            {"inventory_number": "123", "other_fields": "dup of record 1"},
+        ]
+
+    def test_unique_values_are_returned(self):
+        singletons = _get_singletons(self.sample_data)
+        self.assertEqual(len(singletons), 2)
+        # Make sure the unique keys are all present.
+        for inventory_number in ["456", "789"]:
+            with self.subTest(inventory_number=inventory_number):
+                self.assertIn(inventory_number, singletons)
+
+    def test_duplicate_values_are_not_returned(self):
+        singletons = _get_singletons(self.sample_data)
+        # Make sure the duplicate key is not present.
+        self.assertNotIn("123", singletons)


### PR DESCRIPTION
Fixes [SYS-1886](https://uclalibrary.atlassian.net/browse/SYS-1886).

This PR fixes a programming error in `get_perfect_matches.py`.  Instead of using inventory numbers which occur only once in a given source, it was using the *first* occurrence of each inventory number.  For example, given (123, 456, 123), it should have been looking only at (123), but was instead looking at (123, 456) (ignoring the duplicate 123).

The fix: do it correctly :) .  Now I'm using `collections.Counter` to find out how many times each inventory number occurs, in each data source, and only keeping the "singletons", those which appear only one in each data source.

To support this, I added a `_get_singletons()` function, and standardized the source data (as needed) after loading it to ensure every record has an `inventory_number` key to be used for counting.

I also added a couple of basic tests, to confirm the behavior is correct, something I didn't do in #16 because "the data manipulation and matching is very simple".  The data *matching* is still simple, just set intersections, but now at least the manipulation gets some testing...

`docker compose exec ftva_data python -m unittest` now shows 15 tests (for all tested scripts), all passing.

See the README (unchanged, except for the new correct counts) for instructions on running the script, if desired.


[SYS-1886]: https://uclalibrary.atlassian.net/browse/SYS-1886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ