### PR TITLE
SYS-1913: Create metadata processing script, including Creator values

### DIFF
--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -1,0 +1,218 @@
+import csv
+import json
+import argparse
+import tomllib
+import spacy
+import logging
+from datetime import datetime
+from pathlib import Path
+from pymarc import Record
+from alma_api_client import AlmaAPIClient, get_pymarc_record_from_bib
+
+# for type hinting
+from spacy.language import Language
+
+
+def _get_arguments() -> argparse.Namespace:
+    """Parse command line arguments.
+
+    :return: Parsed arguments for config_file, input_file, and
+    output_file as a Namespace object."""
+    parser = argparse.ArgumentParser(description="Process metadata for MAMS ingestion.")
+    parser.add_argument(
+        "--config_file", help="Path to configuration file", required=True
+    )
+    parser.add_argument(
+        "--input_file",
+        type=str,
+        required=True,
+        help="Path to the input CSV file containing Alma holdings IDs and other metadata.",
+    )
+    parser.add_argument(
+        "--output_file",
+        type=str,
+        required=True,
+        help="Path to the output JSON file where processed metadata will be saved.",
+    )
+    return parser.parse_args()
+
+
+def _get_config(config_file_name: str) -> dict:
+    """Returns configuration for this program, loaded from TOML file.
+
+    :param config_file_name: Path to the configuration file.
+    :return: Configuration dictionary."""
+
+    with open(config_file_name, "rb") as f:
+        config = tomllib.load(f)
+    return config
+
+
+def _get_logger(name: str | None = None) -> logging.Logger:
+    """
+    Returns a logger for the current application.
+    A unique log filename is created using the current time, and log messages
+    will use the name in the 'logger' field.
+
+    :param name: Optional name for the logger. If not provided, uses the base filename
+    of the current script.
+    :return: Configured logger instance."""
+
+    if not name:
+        # Use base filename of current script.
+        name = Path(__file__).stem
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    logging_filename = f"{name}_{timestamp}.log"
+    logger = logging.getLogger(name)
+    logging.basicConfig(
+        filename=logging_filename,
+        level=logging.DEBUG,
+        format="%(asctime)s %(levelname)s: %(message)s",
+    )
+    return logger
+
+
+def _read_input_file(file_path: str) -> list:
+    """Read the input CSV file and return a list of dictionaries.
+
+    :param file_path: Path to the input CSV file.
+    :return: List of dictionaries representing each row in the CSV file."""
+    with open(file_path, mode="r", encoding="utf-8-sig") as file:
+        reader = csv.DictReader(file)
+        return [row for row in reader]
+
+
+def _get_bib_record(client: AlmaAPIClient, mms_id: str) -> Record:
+    """Gets a bib record with holding data from Alma API.
+
+    :param client: Alma API client instance.
+    :param mms_id: Alma MMS ID for the bib record.
+    :return: Pymarc Record object containing the bib data."""
+    bib_data = client.get_bib(mms_id).get("content")
+    bib_record = get_pymarc_record_from_bib(bib_data)
+    return bib_record
+
+
+def _get_creator_info_from_bib(bib_record: Record) -> list:
+    """Extract creators from the MARC bib record.
+
+    :param bib_record: Pymarc Record object containing the bib data.
+    :return: List of strings potentially containing creator names."""
+    creators = []
+    # MARC 245 $c is not repeatable, so we will always take the first one.
+    marc_245_c = (
+        bib_record.get_fields("245")[0].get_subfields("c")
+        if bib_record.get_fields("245")
+        else []
+    )
+
+    creators.extend(marc_245_c)
+    return creators
+
+
+def _parse_creators(source_string: str, model: Language) -> list:
+    """Given a string sourced from MARC data, parse it to extract creator names.
+    First, a list of attribution phrases is checked to see if the string
+    contains any of them. If it does, the substring following the phrase
+    is processed with a spacy NER model to extract names.
+
+    :param source_string: String containing creator names from MARC data.
+    :param model: Spacy language model for NER.
+    :return: List of creator names."""
+
+    attribution_phrases = [
+        "directed by",
+        "director",  # This will also match "directors"
+        "a film by",
+        "supervised by",
+    ]
+    # Find location of the first attribution phrase
+    for phrase in attribution_phrases:
+        if phrase in source_string.lower():
+            start_index = source_string.lower().find(phrase) + len(phrase)
+            # Extract substring after the phrase until the end of the string
+            # TODO: Does this work in general? Could a director be listed before
+            # a non-director role that we shoudn't include?
+            creator_string = source_string[start_index:].strip()
+            break
+
+    if not creator_string:
+        return []
+
+    doc = model(creator_string)
+    creators = []
+    for ent in doc.ents:
+        if ent.label_ == "PERSON":
+            creators.append(ent.text)
+    return creators
+
+
+def _get_creators(bib_record: Record, model: Language) -> list:
+    """Extract and parse creator names from a MARC bib record.
+
+    :param bib_record: Pymarc Record object containing the bib data.
+    :param model: Spacy language model for NER.
+    :return: List of parsed creator names."""
+    creators = _get_creator_info_from_bib(bib_record)
+    parsed_creators = []
+    for creator in creators:
+        parsed_creators.extend(_parse_creators(creator, model))
+    return parsed_creators
+
+
+def _write_output_file(output_file: str, data: list) -> None:
+    """Write processed data to a JSON file.
+
+    :param output_file: Path to the output JSON file.
+    :param data: List of dictionaries containing processed metadata."""
+    with open(output_file, mode="w", encoding="utf-8") as file:
+        json.dump(data, file, indent=4)
+
+
+def main():
+    args = _get_arguments()
+    config = _get_config(args.config_file)
+    api_key = config["alma_config"]["alma_api_key"]
+    logger = _get_logger()
+
+    # Read input file
+    logger.info(f"Loading input data from {args.input_file}")
+    input_data = _read_input_file(args.input_file)
+    logger.info(f"Loaded {len(input_data)} records from input file.")
+
+    # Initialize Alma API client
+    alma_client = AlmaAPIClient(api_key)
+
+    # Load spacy model for NER
+    # TODO: Support use of a custom model, if needed
+    nlp_model = spacy.load("en_core_web_md")
+
+    # Process each row in the input data
+    processed_data = []
+    for row in input_data:
+        alma_mms_id = row.get("alma_bib_id")
+        bib_record = _get_bib_record(alma_client, alma_mms_id)
+        if not bib_record:
+            logger.warning(
+                f"No bib record found for Alma MMS ID: {alma_mms_id}. Skipping row."
+            )
+            continue
+        # Process each desired field for metadata extraction
+        creators = _get_creators(bib_record, nlp_model)
+
+        processed_row = {
+            "alma_bib_id": alma_mms_id,
+            "alma_holdings_id": row.get("alma_holdings_id"),
+            "pd_record_id": row.get("pd_record_id"),
+            "django_record_id": row.get("django_record_id"),
+            "creator": creators,
+        }
+        processed_data.append(processed_row)
+
+    # Save processed data to output JSON file
+    _write_output_file(args.output_file, processed_data)
+    logger.info(f"Processed data saved to {args.output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -89,7 +89,7 @@ def _get_bib_record(client: AlmaAPIClient, mms_id: str) -> Record:
     :param client: Alma API client instance.
     :param mms_id: Alma MMS ID for the bib record.
     :return: Pymarc Record object containing the bib data."""
-    bib_data = client.get_bib(mms_id).get("content")
+    bib_data: bytes = client.get_bib(mms_id).get("content", b"")
     bib_record = get_pymarc_record_from_bib(bib_data)
     return bib_record
 
@@ -120,6 +120,9 @@ def _parse_creators(source_string: str, model: Language) -> list:
     :param source_string: String containing creator names from MARC data.
     :param model: Spacy language model for NER.
     :return: List of creator names."""
+
+    # Initialize an empty string for the creator string
+    creator_string = ""
 
     attribution_phrases = [
         "directed by",
@@ -170,7 +173,7 @@ def _write_output_file(output_file: str, data: list) -> None:
         json.dump(data, file, indent=4)
 
 
-def main():
+def main() -> None:
     args = _get_arguments()
     config = _get_config(args.config_file)
     api_key = config["alma_config"]["alma_api_key"]

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -26,12 +26,13 @@ def _get_arguments() -> argparse.Namespace:
         "--input_file",
         type=str,
         required=True,
-        help="Path to the input CSV file containing Alma holdings IDs and other metadata.",
+        help="Path to the input CSV file containing record identifiers.",
     )
     parser.add_argument(
         "--output_file",
         type=str,
-        required=True,
+        default="processed_metadata.json",
+        required=False,
         help="Path to the output JSON file where processed metadata will be saved.",
     )
     return parser.parse_args()
@@ -199,6 +200,7 @@ def main():
             continue
         # Process each desired field for metadata extraction
         creators = _get_creators(bib_record, nlp_model)
+        # TODO: Add additional metadata fields as needed
 
         processed_row = {
             "alma_bib_id": alma_mms_id,


### PR DESCRIPTION
Implements [SYS-1913](https://uclalibrary.atlassian.net/browse/SYS-1913)

Adds a new script, `generate_metadata.py`, intended for use with 1-1-1 matches. The script takes a CSV file containing Alma MMS IDs (plus other identifiers) and creates a JSON file with the specified filename. For now, the JSON file contains one object for each row. Each object contains the data from the original CSV plus extracted Creator names.

Script arguments: 
* `--config_file`: a TOML config file, as used by other scripts in this repo. This is currently only used for the `alma_api_key` value.
* `--input_file`: a CSV file containing identifiers. Expected column headers are `alma_bib_id`, `alma_holdings_id`, `pd_record_id`, and `django_record_id`.
* `--output_file` (optional): desired path to the output JSON file. Defaults to `processed_metadata.json`.

Notes:

* The [Test Plan Confluence page](https://uclalibrary.atlassian.net/wiki/spaces/pm/pages/1293058248/Test+Plan+-+July+2025) does not include MMS IDs. We need these in order to get bibliographic metadata from Alma, and the Alma API doesn't seem to offer any way to work backwards and identify a MMS ID associated with a given Holdings ID. For now, I'm assuming we can include MMS IDs in input data.
* The [Alma record](https://search.library.ucla.edu/permalink/01UCS_LAL/17p22dp/alma991276403506533) indicated in the Test Plan does not have Creator information (245 $c). So to test creator extraction, I grabbed Alma IDs for a different Twilight Zone episode with a 245 $c containing a director and included it as the second row in the CSV data below.

No automated tests are included with this PR. To try the script manually, save the below as `sample_input.csv`, then run (in the container):
```python generate_metadata.py --input_file sample_input.csv --config_file prod_config_secrets.toml```. The output JSON file will be created as `processed_metadata.json`. A short log file will be created as `generate_metadata_{date}_{time}.log`.

```
alma_bib_id,alma_holdings_id,pd_record_id,django_record_id
991276403506533,22549193640006533,408716,999
991702153506533,22548952040006533,123456,888
```

[SYS-1913]: https://uclalibrary.atlassian.net/browse/SYS-1913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ