### PR TITLE
SYS-1918: add date to generate_metadata.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_
 en_core_web_md @ https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.7.1/en_core_web_md-3.7.1-py3-none-any.whl
 # For Filemaker API access
 python-fmrest==1.7.5
+# For metadata extraction
+python-dateutil==2.9.0


### PR DESCRIPTION
Implements [SYS-1918](https://uclalibrary.atlassian.net/browse/SYS-1918)

This PR adds date extraction to `generate_metadata.py`. A date is extracted from the first 260 ## $c, parsed into a standard format (if possible), and included in the output JSON as `release_broadcast_date`.

In order to do anything beyond trivial parsing (i.e. when dates are already YYYY-MM-DD), I'm using `dateutil`, which is added to `requirements.txt`. 

Note that this implementation does not preserve the level of precision of the original data. If an incomplete date is input, the `dateutil` parser will fill in a default value for missing data, currently using values from the current timestamp (so "April 2023" will come out as "2023-04-17" today, since it's 7/17). In order to correctly handle these cases, I think we'll need to use regexes to determine the original level of precision. Our sample data does have a full date value, so this implementation should work for our immediate needs.

Rebuild the container to install the new library, and then run: `python generate_metadata.py --input_file sample_input.csv --config_file prod_config_secrets.toml`