### PR TITLE
SYS-1919: Add language to generate_metadata.py

### DIFF
--- a/tests/test_generate_metadata.py
+++ b/tests/test_generate_metadata.py
@@ -1,0 +1,87 @@
+import logging
+import unittest
+from pymarc import Field, Indicators, Record, Subfield
+from generate_metadata import _get_language_name, _get_language_map
+
+
+class TestGenerateMetadata(unittest.TestCase):
+    def setUp(self):
+        # Turn off logging for this test case, for all but CRITICAL
+        # which we don't generally use.
+        # Otherwise, test output is cluttered with log messages from
+        # methods being tested.
+        logging.disable(level=logging.CRITICAL)
+
+        self.language_map = _get_language_map("language_map.json")
+        self.minimal_bib_record = self._get_minimal_bib_record()
+
+    def _get_minimal_bib_record(self) -> Record:
+        """Create a valid but minimal bib record with just 001 and 245 $a.
+        This will be used as the base record, then copied & modified
+        for other tests as needed.
+
+        :return record: Minimal bib record with just 001 and 245 fields.
+        """
+        field_001 = Field(tag="001", data="12345")
+        field_245 = Field(
+            tag="245",
+            indicators=Indicators("0", "0"),
+            subfields=[Subfield(code="a", value="F245a")],
+        )
+        record = Record()
+        record.add_field(field_001)
+        record.add_field(field_245)
+        return record
+
+    def _get_bib_record_bad_008(self) -> Record:
+        """Create a bib record with an invalid 008 field,
+        with bad data and incorrect length.
+
+        :return record: Minimal bib record with a bad 008 field.
+
+        """
+        bad_field_008 = Field(tag="008", data="xxxxxxxxxxxxxxxx")
+        record = self.minimal_bib_record
+        record.add_field(bad_field_008)
+        return record
+
+    def test_get_language_name_no_008(self):
+        # The minimal record has no 008 field.
+        record = self.minimal_bib_record
+        language_name = _get_language_name(record, self.language_map)
+        self.assertEqual(language_name, "")
+
+    def test_get_language_name_bad_008(self):
+        record = self._get_bib_record_bad_008()
+        language_name = _get_language_name(record, self.language_map)
+        self.assertEqual(language_name, "")
+
+    def test_get_language_name_invalid_code(self):
+        # The minimal record has no 008 field; add one with an invalid
+        # language code in positions 35-37.  Other data in the 008
+        # does not matter for this, so use spaces.
+
+        # A bib 008 field must have 40 characters.
+        spaces = " " * 40
+        # Set positions 35-37 to an invalid language code (not in the language map).
+        field_008_data = spaces[:35] + "BAD" + spaces[38:]
+        record = self.minimal_bib_record
+        # Add the bad 008 field
+        record.add_field(Field(tag="008", data=field_008_data))
+        language_name = _get_language_name(record, self.language_map)
+        self.assertEqual(language_name, "")
+
+    def test_get_language_name_valid_code(self):
+        # The minimal record has no 008 field; add one with a valid
+        # language code in positions 35-37.  Other data in the 008
+        # does not matter for this, so use spaces.
+
+        # A bib 008 field must have 40 characters.
+        spaces = " " * 40
+        # Set positions 35-37 to a valid language code (in the language map).
+        field_008_data = spaces[:35] + "fre" + spaces[38:]
+        record = self.minimal_bib_record
+        # Add the good 008 field
+        record.add_field(Field(tag="008", data=field_008_data))
+        language_name = _get_language_name(record, self.language_map)
+        self.assertEqual(language_name, "French")


### PR DESCRIPTION
Implements [SYS-1919](https://uclalibrary.atlassian.net/browse/SYS-1919).

This PR adds language name to `generate_metadata.py`.  For each bib record processed, the MARC language code is extracted from the 008, positions 35-37. Then the code is used to look up the full name of the language in a pre-existing mapping table.

If the 008 is missing or invalid, or if the language code can't be found in the mapping table, warning(s) are logged.

The mapping table must exist.  If you don't have it already, run `python create_language_map.py` to generate it.

With the small `sample_input.csv` we've been using, run:

```
python generate_metadata.py --input_file sample_input.csv --config_file prod_config_secrets.toml
```
There's an optional `--language_map` argument which can be used; if not supplied, it defaults to the default `language_map.json` generated by `create_language_map.py`.

JSON output is in `processed_metadata.json`.  Both of our current sample records should have `"language": "English"`.

[**EDIT: ADDED TESTS**]

There is a new test file for the script, `test_generate_metadata.py`.  It currently contains 4 tests, covering the core functionality in this PR.  This should also be used as a model for other tests of `generate_metadata.py`.

Currently 22 passing tests in the whole project:
`docker compose exec ftva_data python -m unittest`

Or if you want to run just the 4 relevant here:
`docker compose exec ftva_data python -m unittest tests.test_generate_metadata`


@ztucker4 please review; @henry-r18 FYI.



[SYS-1919]: https://uclalibrary.atlassian.net/browse/SYS-1919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ