### PR TITLE
SYS-1921: add asset type and file name to metadata script

### DIFF
--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -339,6 +339,16 @@ def _get_asset_type(item: dict) -> str:
 
     :param item: Dictionary containing metadata for a record.
     :return: The asset type string, or an empty string if not found."""
+    # DPX files are special, so check for them first
+    file_type = _get_file_type(item)
+    if file_type == "DPX":
+        lower_folder_name = _get_folder_name(item).lower()
+        if "mti" in lower_folder_name:
+            return "Intermediate"
+        else:
+            return "Raw"
+
+    # Non-DPX files are handled by checking the file_name
     file_name = _get_file_name(item)
     if not file_name:
         return ""

--- a/tests/test_generate_metadata.py
+++ b/tests/test_generate_metadata.py
@@ -110,3 +110,13 @@ class TestGenerateMetadata(unittest.TestCase):
         item = {"file_name": "example_file.mov"}
         asset_type = _get_asset_type(item)
         self.assertEqual(asset_type, "")
+
+    def test_get_asset_type_dpx_intermediate(self):
+        item = {"folder_name": "example_folder_MTI", "file_type": "DPX"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "Intermediate")
+
+    def test_get_asset_type_dpx_raw(self):
+        item = {"folder_name": "example_folder", "file_type": "DPX"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "Raw")

--- a/tests/test_generate_metadata.py
+++ b/tests/test_generate_metadata.py
@@ -1,7 +1,7 @@
 import logging
 import unittest
 from pymarc import Field, Indicators, Record, Subfield
-from generate_metadata import _get_language_name, _get_language_map
+from generate_metadata import _get_language_name, _get_language_map, _get_asset_type
 
 
 class TestGenerateMetadata(unittest.TestCase):
@@ -85,3 +85,28 @@ class TestGenerateMetadata(unittest.TestCase):
         record.add_field(Field(tag="008", data=field_008_data))
         language_name = _get_language_name(record, self.language_map)
         self.assertEqual(language_name, "French")
+
+    def test_get_asset_type_raw(self):
+        item = {"file_name": "example_raw_file.mov"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "Raw")
+
+    def test_get_asset_type_intermediate(self):
+        item = {"file_name": "example_file_mti.mov"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "Intermediate")
+
+    def test_get_asset_type_final(self):
+        item = {"file_name": "example_file_final.mov"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "Final Version")
+
+    def test_get_asset_type_derivative(self):
+        item = {"file_name": "example_file_finals_finals.mov"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "Derivative")
+
+    def test_get_asset_type_unknown(self):
+        item = {"file_name": "example_file.mov"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "")


### PR DESCRIPTION
Implements [SYS-1921](https://uclalibrary.atlassian.net/browse/SYS-1921)

Adds the following logic to `generate_metadata.py`:

* Adds `file_name` to output JSON for all data rows. 
* Determines an `asset_type`, if possible, for all data rows and adds this to the output.
* For DPX files only, adds `folder_name` to the output.

Asset type determination is based on the [ETL specs](https://uclalibrary.atlassian.net/wiki/spaces/pm/pages/1293385853/Legacy+ETL+1-1-1#Custom%3A-Asset-Type), updated this morning after Slack discussion with Thelma and Christina. The logic differs for DPX and non-DPX items. File and folder names are taken directly from the input CSV file.

Using the new version of `sample_input.csv` I sent in Slack this morning, run: `python generate_metadata.py --input_file sample_input.csv --config_file prod_config_secrets.toml`

Also includes 7 new tests for the only new function with any significant logic, `_get_asset_type()`. To run them: `docker compose exec ftva_data python -m unittest tests.test_generate_metadata`