### PR TITLE
SYS-1915: Add titles to `generate_metadata.py`

### DIFF
--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -203,7 +203,7 @@ def _get_main_title_from_bib(bib_record: Record) -> str:
         main_title = title_field[0].get_subfields("a")
         if main_title:
             # 245 $a is NR, so take first item
-            return _strip_whitespace_and_punctuation(main_title)[0]
+            return main_title[0]
     # If no main title found, log a warning and return an empty string.
     logging.warning(f"No main title (245 $a) found in bib record {bib_record['001']}.")
     return ""
@@ -222,7 +222,7 @@ def _get_alternative_titles_from_bib(bib_record: Record) -> list[str]:
             # Per specs, only take 246 $a if indicator1 is 0, 2, or 3 and indicator2 is empty
             if field.indicator1 in ["0", "2", "3"] and field.indicator2 == " ":
                 alternative_titles += field.get_subfields("a")
-    return _strip_whitespace_and_punctuation(alternative_titles)
+    return alternative_titles
 
 
 def _get_series_title_from_bib(bib_record: Record, main_title: str) -> str:
@@ -254,6 +254,8 @@ def _get_episode_title_from_bib(bib_record: Record) -> str:
         if name_of_part:
             # Per specs, if there are multiple 245 $p, take the first one.
             # Assign it as a list though, so it can be easily joined with other lists.
+            # Specs say episode titles specifically
+            # should be stripped of whitespace and punctuation.
             name_of_part = [_strip_whitespace_and_punctuation(name_of_part)[0]]
 
         number_of_part = _strip_whitespace_and_punctuation(

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -275,7 +275,7 @@ def _get_episode_title_from_bib(bib_record: Record) -> str:
     return ""
 
 
-def _get_titles(bib_record: Record) -> dict:
+def _get_title_info(bib_record: Record) -> dict:
     """Extract title fields from a MARC bib record.
 
     :param bib_record: Pymarc Record object containing the bib data.

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -198,12 +198,11 @@ def _get_main_title_from_bib(bib_record: Record) -> str:
     :param bib_record: Pymarc Record object containing the bib data.
     :return: Main title string, or an empty string if not found.
     """
-    title_field = bib_record.get_fields("245")
+    title_field = bib_record.get("245")
     if title_field:
-        main_title = title_field[0].get_subfields("a")
+        main_title = title_field.get("a")  # 245 $a is NR, so take first item
         if main_title:
-            # 245 $a is NR, so take first item
-            return main_title[0]
+            return main_title
     # If no main title found, log a warning and return an empty string.
     logging.warning(f"No main title (245 $a) found in bib record {bib_record['001']}.")
     return ""
@@ -217,11 +216,10 @@ def _get_alternative_titles_from_bib(bib_record: Record) -> list[str]:
     """
     alternative_titles = []
     alternative_titles_field = bib_record.get_fields("246")
-    if alternative_titles_field:
-        for field in alternative_titles_field:
-            # Per specs, only take 246 $a if indicator1 is 0, 2, or 3 and indicator2 is empty
-            if field.indicator1 in ["0", "2", "3"] and field.indicator2 == " ":
-                alternative_titles += field.get_subfields("a")
+    for field in alternative_titles_field:
+        # Per specs, only take 246 $a if indicator1 is 0, 2, or 3 and indicator2 is empty
+        if field.indicator1 in ["0", "2", "3"] and field.indicator2 == " ":
+            alternative_titles += field.get_subfields("a")
     return alternative_titles
 
 
@@ -231,10 +229,10 @@ def _get_series_title_from_bib(bib_record: Record, main_title: str) -> str:
     :param bib_record: Pymarc Record object containing the bib data.
     :return: The series title string, or an empty string.
     """
-    title_field = bib_record.get_fields("245")
+    title_field = bib_record.get("245")
     if title_field:
-        number_of_part = title_field[0].get_subfields("n")
-        name_of_part = title_field[0].get_subfields("p")
+        number_of_part = title_field.get_subfields("n")
+        name_of_part = title_field.get_subfields("p")
         if number_of_part or name_of_part:
             return main_title  # series title is main title if 245 $n or 245 $p exist
     return ""
@@ -248,9 +246,9 @@ def _get_episode_title_from_bib(bib_record: Record) -> str:
     """
     name_of_part = []  # Init to avoid being potentially unbound
     number_of_part = []
-    title_field = bib_record.get_fields("245")
+    title_field = bib_record.get("245")
     if title_field:
-        name_of_part = title_field[0].get_subfields("p")
+        name_of_part = title_field.get_subfields("p")
         if name_of_part:
             # Per specs, if there are multiple 245 $p, take the first one.
             # Assign it as a list though, so it can be easily joined with other lists.
@@ -259,7 +257,7 @@ def _get_episode_title_from_bib(bib_record: Record) -> str:
             name_of_part = [_strip_whitespace_and_punctuation(name_of_part)[0]]
 
         number_of_part = _strip_whitespace_and_punctuation(
-            title_field[0].get_subfields("n")
+            title_field.get_subfields("n")
         )
 
     alternative_number_of_part = []

--- a/tests/test_generate_metadata.py
+++ b/tests/test_generate_metadata.py
@@ -8,7 +8,7 @@ from generate_metadata import (
     _get_alternative_titles_from_bib,
     _get_series_title_from_bib,
     _get_episode_title_from_bib,
-    _get_titles,
+    _get_title_info,
     _get_asset_type,
 )
 
@@ -205,7 +205,7 @@ class TestGenerateMetadata(unittest.TestCase):
         )
         self.assertEqual(episode_title, expected_output)
 
-    def test_get_titles(self):
+    def test_get_title_info(self):
         # Testing the main coordinating function
         # that calls all the smaller title-specific methods.
 
@@ -237,5 +237,5 @@ class TestGenerateMetadata(unittest.TestCase):
             "alternative_titles": ["F246a_1", "F246a_2"],
             "episode_title": "F245p. F245n. F246n_1. F246n_2",
         }
-        titles = _get_titles(record)
+        titles = _get_title_info(record)
         self.assertEqual(titles, expected_output)

--- a/tests/test_generate_metadata.py
+++ b/tests/test_generate_metadata.py
@@ -164,31 +164,33 @@ class TestGenerateMetadata(unittest.TestCase):
 
     def test_get_series_title(self):
         record = self.minimal_bib_record
-        field_245 = record.get_fields("245")[0]
+        field_245 = record.get("245")
 
         main_title = record.get_fields("245")[0].get_subfields("a")[0]
         series_subfield_codes = ["n", "p", "g"]  # g should result in ""
         for code in series_subfield_codes:
             with self.subTest(code=code):
-                field_245.add_subfield(code=code, value=f"F245{code}")
-                series_title = _get_series_title_from_bib(record, main_title)
-                # If 245 $n or 245 $p exists on record,
-                # series title should be main title (245 $a),
-                # else it should be an empty string.
-                if code in ["n", "p"]:  #
-                    self.assertEqual(series_title, main_title)
-                else:
-                    self.assertEqual(series_title, "")
-                field_245.delete_subfield(code=code)
+                if field_245:  # this is just to avoid linting errors
+                    field_245.add_subfield(code=code, value=f"F245{code}")
+                    series_title = _get_series_title_from_bib(record, main_title)
+                    # If 245 $n or 245 $p exists on record,
+                    # series title should be main title (245 $a),
+                    # else it should be an empty string.
+                    if code in ["n", "p"]:  #
+                        self.assertEqual(series_title, main_title)
+                    else:
+                        self.assertEqual(series_title, "")
+                    field_245.delete_subfield(code=code)
 
     def test_get_episode_title(self):
         record = self.minimal_bib_record
-        field_245 = record.get_fields("245")[0]
-        field_245.add_subfield(code="n", value="Episode 001")
-        field_245.add_subfield(
-            code="p",
-            value="Pilot--unedited footage. Pam Jennings interviews Marlon Riggs",
-        )
+        field_245 = record.get("245")
+        if field_245:  # to avoid linting error
+            field_245.add_subfield(code="n", value="Episode 001")
+            field_245.add_subfield(
+                code="p",
+                value="Pilot--unedited footage. Pam Jennings interviews Marlon Riggs",
+            )
 
         field_246 = Field(tag="246", subfields=[Subfield(code="n", value="F246n")])
         record.add_field(field_246)
@@ -210,9 +212,10 @@ class TestGenerateMetadata(unittest.TestCase):
         # that calls all the smaller title-specific methods.
 
         record = self.minimal_bib_record
-        field_245 = record.get_fields("245")[0]
-        field_245.add_subfield(code="n", value="F245n")
-        field_245.add_subfield(code="p", value="F245p")
+        field_245 = record.get("245")
+        if field_245:  # to avoid linting error
+            field_245.add_subfield(code="n", value="F245n")
+            field_245.add_subfield(code="p", value="F245p")
 
         field_246_1 = Field(
             tag="246",


### PR DESCRIPTION
Implements [SYS-1915](https://uclalibrary.atlassian.net/browse/SYS-1915)

### Acceptance criteria
- [x] Title information (title, alternative_title, series_title, and episode_title) is generated by the script generate_metadata.py (now merged and available via SYS-1913) in the ftva-mams-data repository.

### Description
This PR adds title information to the data extracted by `generate_metadata.py`. The logic described in the ETL specs is implemented in four title-specific functions, coordinated by a main function called `_get_title_info`. The main function checks the input MARC bib record for the various types of titles (i.e. `title`, `alternative_titles`, `series_title`, and `episode_title`), then uses conditionals to add appropriate titles to a dict that is then unpacked into the primary `processed_row` dict.

I found that it was tricky to follow the multiple combinations of title-types and conditionals described in the specs, and I made some inferences, especially with the `episode_title` section. I can refine the implementation of the logic once we have more sample inputs.

### Testing
I added 6 tests for these title-related functions, bringing the total number of unit tests to 28. The tests I wrote could probably use refinement for clarity, but I wanted to get this PR submitted sooner rather than later.

[SYS-1915]: https://uclalibrary.atlassian.net/browse/SYS-1915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ