### PR TITLE
SYS-1920: Add inventory number and clean up ids

### DIFF
--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -532,13 +532,12 @@ def main() -> None:
         language_name = _get_language_name(bib_record, language_map)
         file_name = _get_file_name(row)
         titles = _get_title_info(bib_record)
-        # TODO: Add additional metadata fields as needed
 
         processed_row = {
             "alma_bib_id": alma_mms_id,
-            "alma_holdings_id": row.get("alma_holdings_id"),
-            "pd_record_id": row.get("pd_record_id"),
-            "django_record_id": row.get("django_record_id"),
+            "inventory_id": row.get("fm_inventory_id"),
+            "dl_record_id": row.get("dl_record_id"),
+            "inventory_number": row.get("inventory_number"),
             "creator": creators,
             "release_broadcast_date": release_broadcast_date,
             "language": language_name,


### PR DESCRIPTION
Implements [SYS-1920](https://uclalibrary.atlassian.net/browse/SYS-1920).

This PR adds `inventory_number` to the JSON output.  It also makes some minor changes to other ids:
* Remove `alma_holdings_id`, which is in the source CSV but not wanted in the output.
* Rename `pd_record_id` to `fm_inventory_id` (just called `inventory_id` in the output).
* Rename `django_record_id` to `dl_record_id`, per the specs.

I also added `inventory_number` as a column to `sample_input.csv`, shared via Slack, and renamed a couple of column headings in the CSV to match the program.

No new tests.  All 10 existing tests for this script still pass:
`docker compose exec ftva_data python -m unittest tests.test_generate_metadata`

Please generate sample JSON and make sure everything's named appropriately.
