### PR TITLE
SYS-1928: Improve JSON metadata output

### DIFF
--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -580,6 +580,16 @@ def main() -> None:
         if asset_type:
             processed_row["asset_type"] = asset_type
 
+        # For now, as final step before finishing with this row's data,
+        # be sure both file_name and folder_name are not set.  This may change in future,
+        # in which case this check should be done during a more appropriate earlier step.
+        if processed_row.get("file_name") and processed_row.get("folder_name"):
+            logger.warning(
+                "Both file_name and folder_name are set for DL record "
+                f"{processed_row.get("dl_record_id")}. Skipping row."
+            )
+            continue
+
         processed_data.append(processed_row)
 
     # Tedial requires all records be under one top-level key called "assets".

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -424,6 +424,29 @@ def _get_file_name(item: dict) -> str:
         logging.warning(
             f"No file name found in item {item.get('alma_bib_id', 'unknown')}."
         )
+
+    # Data currently has many "suffixes" (.something) which are not valid file suffixes.
+    # These are the ones we have which are known to be valid.
+    valid_suffixes = [
+        ".bup",
+        ".ifo",
+        ".qt",
+        ".vob",
+        ".fcp",
+        ".jpg",
+        ".m4v",
+        ".mov",
+        ".mp4",
+        ".mpg4",
+        ".ncor",
+        ".png",
+        ".raw",
+        ".wav",
+    ]
+    # Remove valid suffixes only, and only the final suffix (not Path.suffixes, which is a list).
+    if Path(file_name).suffix in valid_suffixes:
+        file_name = Path(file_name).stem
+
     return file_name
 
 

--- a/tests/test_generate_metadata.py
+++ b/tests/test_generate_metadata.py
@@ -10,6 +10,7 @@ from generate_metadata import (
     _get_episode_title_from_bib,
     _get_title_info,
     _get_asset_type,
+    _get_file_name,
 )
 
 
@@ -277,3 +278,23 @@ class TestGenerateMetadata(unittest.TestCase):
         }
         titles = _get_title_info(record)
         self.assertEqual(titles, expected_output)
+
+    def test_get_file_name_valid_extension(self):
+        item = {"file_name": "filename.wav"}
+        file_name = _get_file_name(item)
+        self.assertEqual(file_name, "filename")
+
+    def test_get_file_name_invalid_extension(self):
+        item = {"file_name": "filename.XYZ"}
+        file_name = _get_file_name(item)
+        self.assertEqual(file_name, "filename.XYZ")
+
+    def test_get_file_name_multiple_extension(self):
+        item = {"file_name": "filename.something.wav"}
+        file_name = _get_file_name(item)
+        self.assertEqual(file_name, "filename.something")
+
+    def test_get_file_name_no_extension(self):
+        item = {"file_name": "filename"}
+        file_name = _get_file_name(item)
+        self.assertEqual(file_name, "filename")

--- a/tests/test_generate_metadata.py
+++ b/tests/test_generate_metadata.py
@@ -95,6 +95,41 @@ class TestGenerateMetadata(unittest.TestCase):
         language_name = _get_language_name(record, self.language_map)
         self.assertEqual(language_name, "French")
 
+    def test_get_asset_type_raw(self):
+        item = {"file_name": "example_raw_file.mov"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "Raw")
+
+    def test_get_asset_type_intermediate(self):
+        item = {"file_name": "example_file_mti.mov"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "Intermediate")
+
+    def test_get_asset_type_final(self):
+        item = {"file_name": "example_file_final.mov"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "Final Version")
+
+    def test_get_asset_type_derivative(self):
+        item = {"file_name": "example_file_finals_finals.mov"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "Derivative")
+
+    def test_get_asset_type_unknown(self):
+        item = {"file_name": "example_file.mov"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "")
+
+    def test_get_asset_type_dpx_intermediate(self):
+        item = {"folder_name": "example_folder_MTI", "file_type": "DPX"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "Intermediate")
+
+    def test_get_asset_type_dpx_raw(self):
+        item = {"folder_name": "example_folder", "file_type": "DPX"}
+        asset_type = _get_asset_type(item)
+        self.assertEqual(asset_type, "Raw")
+
     def test_get_main_title_minimal_record(self):
         record = self.minimal_bib_record
         main_title = _get_main_title_from_bib(record)

--- a/tests/test_generate_metadata.py
+++ b/tests/test_generate_metadata.py
@@ -272,6 +272,7 @@ class TestGenerateMetadata(unittest.TestCase):
         record.add_field(field_246_1, field_246_2)
 
         expected_output = {
+            "title": "F245a F245p. F245n. F246n_1. F246n_2",
             "series_title": "F245a",  # main title from minimal record
             "alternative_titles": ["F246a_1", "F246a_2"],
             "episode_title": "F245p. F245n. F246n_1. F246n_2",


### PR DESCRIPTION
Implements [SYS-1928](https://uclalibrary.atlassian.net/browse/SYS-1928).

This PR makes 3 changes to the JSON output of `generate_metadata.py`:
* `_get_file_name()` now removes known extensions from `file_name`. 
  * The list of `valid_suffixes` is all the ones I recognized (or looked up) from checking `Path(file_name).suffix` against all `file_name` values in the database.  There are many which don't fit this list, so they aren't removed (pending vendor input).
  * Only the last suffix is removed.  For example, `file.wav.wav` -> `file.wav`.  If the vendor has concerns, we can make this recursive later.
  * 4 new test cases were added (previously, `_get_file_name()` was too simple for tests).
* `_get_title_info()` now always sets a `title` key, representing the main / primary title.
  * Previously `title` was only set when both `series_title` and `episode_title` did not exist.
  * Now, if series and episode titles are set, `title` is set to a concatenation of them; otherwise, it's set to `main_title` (an internal value, containing 245 $a).
  * The relevant test `test_get_title_info()` was updated.
* In `main()`, just before a row's data is added to `processed_data` for output, there are 2 new checks:
  * If `file_name` and `folder_name` both have values, a warning is logged and the row is skipped.
  * If `title` does not have a value, a warning is logged and the row is skipped.

I also found that all 7 of the tests for `asset_type` had mistakenly been removed (added in #22 , lost in #23 - my fault for not catching this rebase oversight when reviewing).  I restored them all :)

Testing:
There now are 21 tests for `generate_metadata.py`, all passing:
`docker compose exec ftva_data python -m unittest tests.test_generate_metadata`

Otherwise, manually review the log and json output from
```
docker compose exec ftva_data python generate_metadata.py \
  --input_file sample_input.csv
  --config_file prod_config_secrets.toml
```

@henry-r18 since you wrote the title logic initially, which is more complex than the other parts, please do the primary review and merge if appropriate.
@ztucker4 FYI.
