### PR TITLE
SYS-1922: retrieve Alma data by call number

### DIFF
--- a/get_alma_data_by_call_number.py
+++ b/get_alma_data_by_call_number.py
@@ -131,8 +131,6 @@ def main() -> None:
             f"Multiple ({number_of_records}) records found for call number "
             f"{args.call_number}"
         )
-        print("Full Alma data:")
-        print(json.dumps(alma_data, indent=4))
     else:
         print(f"Single record found for call number {args.call_number}")
         relevant_fields = get_relevant_fields_alma(alma_data)


### PR DESCRIPTION
Implements [SYS-1922](https://uclalibrary.atlassian.net/browse/SYS-1922)

For now, a stand-alone script that retrieves Alma data by call number using the SRU protocol. To run: `python get_alma_data_by_call_number.py --config_file {config_file.toml} --call_number M03016`

Like the corresponding Filemaker script, this script will check if the given call number matches a single Alma record, and print the [specified MARC data fields](https://uclalibrary.atlassian.net/wiki/spaces/pm/pages/1305214995/Digital+Data+Preview+fields) if so.

The output JSON is currently pretty ugly, and will need to be cleaned up before display to end users. I considered trying to convert the original XML to a `pymarc` Record and doing manipulations on that object, but I don't think that would actually save us much effort when putting together the display.

[SYS-1922]: https://uclalibrary.atlassian.net/browse/SYS-1922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ