### PR TITLE
SYS-1974: Use `ftva_etl` package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.13-slim-bookworm
 
 # Install git, required to install the alma_api_client package from github.
 RUN apt-get update && \

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -2,17 +2,15 @@ import csv
 import json
 import argparse
 import tomllib
-import spacy
 import logging
-import dateutil.parser
-import string
 from datetime import datetime
 from pathlib import Path
-from pymarc import Record
-from alma_api_client import AlmaAPIClient, get_pymarc_record_from_bib
-
-# for type hinting
-from spacy.language import Language
+from ftva_etl import (
+    AlmaSRUClient,
+    FilemakerClient,
+    DigitalDataClient,
+    get_mams_metadata,
+)
 
 
 def _get_arguments() -> argparse.Namespace:
@@ -22,27 +20,22 @@ def _get_arguments() -> argparse.Namespace:
     output_file as a Namespace object."""
     parser = argparse.ArgumentParser(description="Process metadata for MAMS ingestion.")
     parser.add_argument(
-        "--config_file", help="Path to configuration file", required=True
+        "--config_file",
+        help="Path to configuration file with API credentials.",
+        required=True,
     )
     parser.add_argument(
         "--input_file",
         type=str,
         required=True,
-        help="Path to the input CSV file containing record identifiers.",
+        help="Path to the input CSV file containing records to be processed.",
     )
     parser.add_argument(
-        "--output_file",
+        "--output_dir",
         type=str,
-        default="processed_metadata.json",
+        default="output/",
         required=False,
-        help="Path to the output JSON file where processed metadata will be saved.",
-    )
-    parser.add_argument(
-        "--language_map",
-        type=str,
-        default="language_map.json",
-        required=False,
-        help="Path to the JSON file containing the code:name language map",
+        help="Path to the output directory where JSON files will be saved. Defaults to 'output/'.",
     )
     return parser.parse_args()
 
@@ -59,8 +52,7 @@ def _get_config(config_file_name: str) -> dict:
 
 
 def _get_logger(name: str | None = None) -> logging.Logger:
-    """
-    Returns a logger for the current application.
+    """Returns a logger for the current application.
     A unique log filename is created using the current time, and log messages
     will use the name in the 'logger' field.
 
@@ -72,27 +64,18 @@ def _get_logger(name: str | None = None) -> logging.Logger:
         # Use base filename of current script.
         name = Path(__file__).stem
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    logging_filename = f"{name}_{timestamp}.log"
+    logging_file = Path("logs", f"{name}_{timestamp}.log")  # Log to `logs/` dir
+    logging_file.parent.mkdir(parents=True, exist_ok=True)  # Make `logs/` dir, if none
     logger = logging.getLogger(name)
     logging.basicConfig(
-        filename=logging_filename,
+        filename=logging_file,
         level=logging.DEBUG,
         format="%(asctime)s %(levelname)s: %(message)s",
     )
     return logger
 
 
-def _get_language_map(file_path: str) -> dict:
-    """Load the language map from a file.
-
-    :param file_path: Path to the language map file.
-    :return: Dictionary with language code:name data.
-    """
-    with open(file_path, "r") as file:
-        return json.load(file)
-
-
-def _read_input_file(file_path: str) -> list:
+def _read_input_file(file_path: str) -> list[dict]:
     """Read the input CSV file and return a list of dictionaries.
 
     :param file_path: Path to the input CSV file.
@@ -102,516 +85,127 @@ def _read_input_file(file_path: str) -> list:
         return [row for row in reader]
 
 
-def _get_bib_record(client: AlmaAPIClient, mms_id: str) -> Record:
-    """Gets a bib record with holding data from Alma API.
-
-    :param client: Alma API client instance.
-    :param mms_id: Alma MMS ID for the bib record.
-    :return: Pymarc Record object containing the bib data."""
-    bib_data: bytes = client.get_bib(mms_id).get("content", b"")
-    bib_record = get_pymarc_record_from_bib(bib_data)
-    return bib_record
-
-
-def _get_creator_info_from_bib(bib_record: Record) -> list:
-    """Extract creators from the MARC bib record.
-
-    :param bib_record: Pymarc Record object containing the bib data.
-    :return: List of strings potentially containing creator names."""
-    creators = []
-    # MARC 245 $c is not repeatable, so we will always take the first one.
-    marc_245_c = (
-        bib_record.get_fields("245")[0].get_subfields("c")
-        if bib_record.get_fields("245")
-        else []
-    )
-
-    creators.extend(marc_245_c)
-    return creators
-
-
-def _parse_creators(source_string: str, model: Language) -> list:
-    """Given a string sourced from MARC data, parse it to extract creator names.
-    First, a list of attribution phrases is checked to see if the string
-    contains any of them. If it does, the substring following the phrase
-    is processed with a spacy NER model to extract names.
-
-    :param source_string: String containing creator names from MARC data.
-    :param model: Spacy language model for NER.
-    :return: List of creator names."""
-
-    # Initialize an empty string for the creator string
-    creator_string = ""
-
-    attribution_phrases = [
-        "directed by",
-        "director",  # This will also match "directors"
-        "a film by",
-        "supervised by",
-    ]
-    # Find location of the first attribution phrase
-    for phrase in attribution_phrases:
-        if phrase in source_string.lower():
-            start_index = source_string.lower().find(phrase) + len(phrase)
-            # Extract substring after the phrase until the end of the string
-            # TODO: Does this work in general? Could a director be listed before
-            # a non-director role that we shoudn't include?
-            creator_string = source_string[start_index:].strip()
-            break
-
-    if not creator_string:
-        return []
-
-    doc = model(creator_string)
-    creators = []
-    for ent in doc.ents:
-        if ent.label_ == "PERSON":
-            creators.append(ent.text)
-    return creators
-
-
-def _get_creators(bib_record: Record, model: Language) -> list:
-    """Extract and parse creator names from a MARC bib record.
-
-    :param bib_record: Pymarc Record object containing the bib data.
-    :param model: Spacy language model for NER.
-    :return: List of parsed creator names."""
-    creators = _get_creator_info_from_bib(bib_record)
-    parsed_creators = []
-    for creator in creators:
-        parsed_creators.extend(_parse_creators(creator, model))
-    return parsed_creators
-
-
-def _strip_whitespace_and_punctuation(items: list[str]) -> list[str]:
-    """A utility function for striping whitespace and punctuation from lists of strings.
-
-    :param items: A list of strings to strip.
-    :return: The list of strings with whitespace and punctuation stripped.
-    """
-    return [item.rstrip(string.punctuation).strip() for item in items]
-
-
-def _get_main_title_from_bib(bib_record: Record) -> str:
-    """Extract the main title from a MARC bib record.
-
-    :param bib_record: Pymarc Record object containing the bib data.
-    :return: Main title string, or an empty string if not found.
-    """
-    title_field = bib_record.get("245")
-    if title_field:
-        main_title = title_field.get("a")  # 245 $a is NR, so take first item
-        if main_title:
-            return main_title
-    # If no main title found, log a warning and return an empty string.
-    logging.warning(f"No main title (245 $a) found in bib record {bib_record['001']}.")
-    return ""
-
-
-def _get_alternative_titles_from_bib(bib_record: Record) -> list[str]:
-    """Extract alternative titles from a MARC bib record.
-
-    :param bib_record: Pymarc Record object containing the bib data.
-    :return: A list of alternative titles, or an empty list if none found.
-    """
-    alternative_titles = []
-    alternative_titles_field = bib_record.get_fields("246")
-    for field in alternative_titles_field:
-        # Per specs, only take 246 $a if indicator1 is 0, 2, or 3 and indicator2 is empty
-        if field.indicator1 in ["0", "2", "3"] and field.indicator2 == " ":
-            alternative_titles += field.get_subfields("a")
-    return alternative_titles
-
-
-def _get_series_title_from_bib(bib_record: Record, main_title: str) -> str:
-    """Determine if record describes series, and return main title as series title if so.
-
-    :param bib_record: Pymarc Record object containing the bib data.
-    :return: The series title string, or an empty string.
-    """
-    title_field = bib_record.get("245")
-    if title_field:
-        number_of_part = title_field.get_subfields("n")
-        name_of_part = title_field.get_subfields("p")
-        if number_of_part or name_of_part:
-            return main_title  # series title is main title if 245 $n or 245 $p exist
-    return ""
-
-
-def _get_episode_title_from_bib(bib_record: Record) -> str:
-    """Extract and format episode title from a MARC bib record.
-
-    :param bib_record: Pymarc Record object containing the bib data.
-    :return: The episode title, formatted according to specs, or an empty string.
-    """
-    name_of_part = []  # Init to avoid being potentially unbound
-    number_of_part = []
-    title_field = bib_record.get("245")
-    if title_field:
-        name_of_part = title_field.get_subfields("p")
-        if name_of_part:
-            # Per specs, if there are multiple 245 $p, take the first one.
-            # Assign it as a list though, so it can be easily joined with other lists.
-            # Specs say episode titles specifically
-            # should be stripped of whitespace and punctuation.
-            name_of_part = [_strip_whitespace_and_punctuation(name_of_part)[0]]
-
-        number_of_part = _strip_whitespace_and_punctuation(
-            title_field.get_subfields("n")
-        )
-
-    alternative_number_of_part = []
-    alternative_titles_field = bib_record.get_fields("246")
-    if alternative_titles_field:
-        for field in alternative_titles_field:
-            alternative_number_of_part += _strip_whitespace_and_punctuation(
-                field.get_subfields("n")
-            )
-
-    if name_of_part or number_of_part or alternative_number_of_part:
-        return ". ".join(name_of_part + number_of_part + alternative_number_of_part)
-    return ""
-
-
-def _get_title_info(bib_record: Record) -> dict:
-    """Extract title fields from a MARC bib record.
-
-    :param bib_record: Pymarc Record object containing the bib data.
-    :return: A dict with available title info.
-    """
-    titles = {}
-
-    main_title = _get_main_title_from_bib(bib_record)
-    alternative_titles = _get_alternative_titles_from_bib(bib_record)
-    series_title = _get_series_title_from_bib(bib_record, main_title)
-    episode_title = _get_episode_title_from_bib(bib_record)
-
-    # Alternative titles are independent of the others.
-    if alternative_titles:
-        titles["alternative_titles"] = alternative_titles
-
-    # The unqualified title ("title") depends on others.
-    if series_title and episode_title:
-        # Concatenate them with just a space, since series title
-        # ends with punctuation (usually... possible refinement later).
-        titles["title"] = f"{series_title} {episode_title}"
-    else:
-        titles["title"] = main_title
-
-    if series_title:
-        titles["series_title"] = series_title
-
-    if episode_title:
-        titles["episode_title"] = episode_title
-
-    return titles
-
-
-def _write_output_file(output_file: str, data: dict) -> None:
+def _write_output_file(output_file: str | Path, data: list[dict]) -> None:
     """Write processed data to a JSON file.
 
     :param output_file: Path to the output JSON file.
-    :param data: List of dictionaries containing processed metadata."""
-    with open(output_file, mode="w", encoding="utf-8") as file:
+    :param data: List of dicts containing processed metadata."""
+    output_path = Path(output_file)
+    # Create parent directories if they don't exist.
+    # Allows for `output_file` to be a relative path.
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, mode="w", encoding="utf-8") as file:
         json.dump(data, file, indent=4)
 
 
-def _get_date_from_bib(bib_record: Record) -> str:
-    """Extract the release_broadcast_date from a MARC bib record.
+def _get_uuid_by_record_id(
+    record_id: int, digital_data_client: DigitalDataClient
+) -> str | None:
+    """Get the UUID of a record by its record ID.
 
-    :param bib_record: Pymarc Record object containing the bib data.
-    :return: Publication date as a string, or an empty string if not found."""
-    # We want the first MARC 260 $c with both indicators blank.
-    date_field = bib_record.get_fields("260")
-    if date_field:
-        for field in date_field:
-            if field.indicator1 == " " and field.indicator2 == " ":
-                date_subfield = field.get_subfields("c")
-                if date_subfield:
-                    return date_subfield[0].strip()
-    # If no date found, return an empty string and log a warning.
-    logging.warning(f"No publication date found in bib record {bib_record['001']}.")
-    return ""
-
-
-def _parse_date(date_string: str) -> str:
-    """Parse a date string into a standardized format.
-
-    :param date_string: Date string to parse.
-    :return: Formatted date string or an empty string if parsing fails."""
-
-    # If the date string is in brackets, remove them temporarily
-    # Remember this so we can add them back later
-    in_brackets = "[" in date_string and "]" in date_string
-    if in_brackets:
-        date_string = date_string.replace("[", "").replace("]", "")
-
-    # Remove trailing punctuation and whitespace
-    date_string = date_string.rstrip(".,;:!?")
-    date_string = date_string.strip()
-
-    # Try to parse the date string using dateutil.parser
-    # TODO: Add handling for underspecified dates, e.g. "2023" or "April 2023"
+    :param record_id: The record ID of the record to get the UUID of.
+    :param digital_data_client: The DigitalDataClient instance to use to get the record.
+    :return: The UUID of the record."""
     try:
-        parsed_date = dateutil.parser.parse(date_string)
-        # Format the date as YYYY-MM-DD
-        formatted_date = parsed_date.strftime("%Y-%m-%d")
-    except (ValueError, dateutil.parser.ParserError) as e:
-        # If parsing fails, log the error and return the original string
-        logging.info(f"Failed to parse date '{date_string}': {e}")
-        formatted_date = date_string
-
-    if in_brackets:
-        formatted_date = f"[{formatted_date}]"
-
-    return formatted_date
+        record = digital_data_client.get_record_by_id(record_id)
+        return record["uuid"]
+    except Exception as error:
+        print(error)
+        _get_logger().error(error)
+        return None
 
 
-def _get_date(bib_record: Record) -> str:
-    """Extract and format release_broadcast_date from a MARC bib record.
+def _initialize_clients(
+    config: dict,
+) -> tuple[AlmaSRUClient, FilemakerClient, DigitalDataClient]:
+    """Initialize the clients for the program.
 
-    :param bib_record: Pymarc Record object containing the bib data.
-    :return: Formatted date string or an empty string if not found."""
-    date_string = _get_date_from_bib(bib_record)
-    if not date_string:
-        return ""
-    return _parse_date(date_string)
+    :param config: The program's configuration dict.
+    :return: A tuple of the initialized clients."""
+    return (
+        AlmaSRUClient(),
+        FilemakerClient(config["filemaker"]["user"], config["filemaker"]["password"]),
+        DigitalDataClient(
+            config["digital_data"]["user"],
+            config["digital_data"]["password"],
+            config["digital_data"]["url"],
+        ),
+    )
 
 
-def _get_language_code_from_bib(bib_record: Record) -> str:
-    """Extract the language code from a MARC bib record.
+def _process_input_data(
+    input_data: list[dict],
+    alma_sru_client: AlmaSRUClient,
+    filemaker_client: FilemakerClient,
+    digital_data_client: DigitalDataClient,
+) -> tuple[list, list]:
+    """Process input data and return lists of asset and track data.
 
-    :param bib_record: Pymarc Record object containing the bib data.
-    :return language_code: The 3-letter MARC language code from the 008/35-37, or an empty string
-    if there is no 008 or the 008 is invalid.
-    """
+    :param input_data: The input data to process.
+    :param alma_sru_client: The AlmaSRUClient instance to use to get the bib record.
+    :param filemaker_client: The FilemakerClient instance to use to get the FM record.
+    :param digital_data_client: The DigitalDataClient instance to use to get the DD record.
+    :return: A tuple of the asset and track data lists."""
+    asset_data = []
+    track_data = []
+    for row in input_data:
+        try:
+            # Retrieve records, logging errors if they occur.
+            digital_data_record = digital_data_client.get_record_by_id(
+                row["dl_record_id"]
+            )
+            inventory_number = digital_data_record["inventory_number"]
+            bib_record = alma_sru_client.search_by_call_number(inventory_number)[0]
+            filemaker_record = filemaker_client.search_by_inventory_number(
+                inventory_number
+            )[0]
+        except Exception as error:
+            print(error)
+            _get_logger().error(error)
+            continue
 
-    language_code = ""
-    # 008 is not repeatable, so .get() instead of .get_fields().
-    field_008 = bib_record.get("008")
-    if field_008:
-        field_data = field_008.data
-        # MARC bib 008 should be 40 characters, or is not valid and can't be trusted
-        # to have specific values in the correct positions.
-        if field_data and len(field_data) == 40:
-            # 3 characters, 0-based 35-37
-            language_code = field_data[35:38]
+        # Initialize to None. Will be set to UUID if record is a track.
+        match_asset_uuid = None
+        if row["Audio Track?"].lower().strip() == "yes":
+            match_asset_uuid = _get_uuid_by_record_id(
+                row["match_asset"], digital_data_client
+            )
+
+        metadata_record = get_mams_metadata(
+            bib_record, filemaker_record, digital_data_record, match_asset_uuid
+        )
+
+        # If metadata_record has `match_asset` value, it's a track.
+        if metadata_record.get("match_asset", None) is not None:
+            track_data.append(metadata_record)
         else:
-            logging.warning(f"Invalid 008 field in bib record {bib_record['001']}")
-    else:
-        logging.warning(f"No 008 field found in bib record {bib_record['001']}.")
-
-    return language_code
-
-
-def _get_language_name(bib_record: Record, language_map: dict) -> str:
-    """Get the full name of the language in a MARC bib record.
-
-    :param bib_record: Pymarc Record object containing the bib data.
-    :param language_table: Dictionary which maps code:name for supported languages.
-    :return language_name: The full name of the language.
-    """
-    language_code = _get_language_code_from_bib(bib_record)
-    language_name = language_map.get(language_code, "")
-    if not language_name:
-        logging.warning(
-            f"No language name found in bib record {bib_record['001']} for {language_code}."
-        )
-    return language_name
-
-
-def _get_file_name(item: dict) -> str:
-    """Get the file name element from a given item dictionary.
-
-    :param item: Dictionary containing metadata for a record.
-    :return: The file name string, or an empty string if not found."""
-    file_name = item.get("file_name", "")
-    if not file_name:
-        logging.warning(
-            f"No file name found in item for Alma MMS ID {item.get('alma_bib_id', 'unknown')}."
-        )
-
-    # Data currently has many "suffixes" (.something) which are not valid file suffixes.
-    # These are the ones we have which are known to be valid.
-    valid_suffixes = [
-        ".bup",
-        ".ifo",
-        ".qt",
-        ".vob",
-        ".fcp",
-        ".jpg",
-        ".m4v",
-        ".mov",
-        ".mp4",
-        ".mpg4",
-        ".ncor",
-        ".png",
-        ".raw",
-        ".wav",
-    ]
-    # Remove valid suffixes only, and only the final suffix (not Path.suffixes, which is a list).
-    if Path(file_name).suffix in valid_suffixes:
-        file_name = Path(file_name).stem
-
-    return file_name
-
-
-def _get_folder_name(item: dict) -> str:
-    """Get the folder name element from a given item dictionary.
-
-    :param item: Dictionary containing metadata for a record.
-    :return: The folder name string, or an empty string if not found."""
-    folder_name = item.get("folder_name", "")
-    if not folder_name:
-        logging.warning(
-            f"No folder name found in item {item.get('alma_bib_id', 'unknown')}."
-        )
-    return folder_name
-
-
-def _get_file_type(item: dict) -> str:
-    """Get the file type element from a given item dictionary.
-
-    :param item: Dictionary containing metadata for a record.
-    :return: The file type string, or an empty string if not found."""
-    file_type = item.get("file_type", "")
-    if not file_type:
-        logging.warning(
-            f"No file type found in item {item.get('alma_bib_id', 'unknown')}."
-        )
-    return file_type
-
-
-def _get_asset_type(item: dict) -> str:
-    """Derive the asset type from the item dictionary, based on the file_name.
-
-    :param item: Dictionary containing metadata for a record.
-    :return: The asset type string, or an empty string if not found."""
-    # DPX files are special, so check for them first
-    file_type = _get_file_type(item)
-    if file_type == "DPX":
-        lower_folder_name = _get_folder_name(item).lower()
-        if "mti" in lower_folder_name:
-            return "Intermediate"
-        else:
-            return "Raw"
-
-    # Non-DPX files are handled by checking the file_name
-    file_name = _get_file_name(item)
-    if not file_name:
-        return ""
-    lower_file_name = file_name.lower()
-
-    raw_values = ["_raw", "_raw_", "capturefiles", "capturedfiles"]
-    if any(raw_value in lower_file_name for raw_value in raw_values):
-        return "Raw"
-    intermediate_values = ["onelite", "inter", "mti", "raw_mti"]
-    if any(
-        intermediate_value in lower_file_name
-        for intermediate_value in intermediate_values
-    ):
-        return "Intermediate"
-
-    # Count the number of "final" (including "finals")
-    # to determine if it's a final or derivative asset
-    final_count = lower_file_name.count("final")
-    if final_count == 1:
-        return "Final Version"
-    elif final_count > 1:
-        return "Derivative"
-
-    # If no specific asset type is determined, return an empty string
-    return ""
+            asset_data.append(metadata_record)
+    return asset_data, track_data
 
 
 def main() -> None:
     args = _get_arguments()
     config = _get_config(args.config_file)
-    api_key = config["alma_config"]["alma_api_key"]
-    logger = _get_logger()
 
     # Read input file
-    logger.info(f"Loading input data from {args.input_file}")
+    _get_logger().info(f"Loading input data from {args.input_file}")
     input_data = _read_input_file(args.input_file)
-    logger.info(f"Loaded {len(input_data)} records from input file.")
+    _get_logger().info(f"Loaded {len(input_data)} records from input file.")
 
-    # Initialize Alma API client
-    alma_client = AlmaAPIClient(api_key)
+    alma_sru_client, filemaker_client, digital_data_client = _initialize_clients(config)
 
-    # Load spacy model for NER
-    # TODO: Support use of a custom model, if needed
-    nlp_model = spacy.load("en_core_web_md")
+    asset_data, track_data = _process_input_data(
+        input_data, alma_sru_client, filemaker_client, digital_data_client
+    )
 
-    # Load language mapping data.
-    language_map = _get_language_map(args.language_map)
-
-    # Process each row in the input data
-    processed_data = []
-    for row in input_data:
-        alma_mms_id = row.get("alma_bib_id")
-        bib_record = _get_bib_record(alma_client, alma_mms_id)
-        if not bib_record:
-            logger.warning(
-                f"No bib record found for Alma MMS ID: {alma_mms_id}. Skipping row."
-            )
-            continue
-        # Process each desired field for metadata extraction
-        creators = _get_creators(bib_record, nlp_model)
-        release_broadcast_date = _get_date(bib_record)
-        language_name = _get_language_name(bib_record, language_map)
-        file_name = _get_file_name(row)
-        titles = _get_title_info(bib_record)
-
-        processed_row = {
-            "alma_bib_id": alma_mms_id,
-            "inventory_id": row.get("fm_inventory_id"),
-            "dl_record_id": row.get("dl_record_id"),
-            "inventory_number": row.get("inventory_number"),
-            "creator": creators,
-            "release_broadcast_date": release_broadcast_date,
-            "language": language_name,
-            "file_name": file_name,
-            **titles,
-        }
-
-        # Add folder name only for DPX files
-        file_type = _get_file_type(row)
-        if file_type == "DPX":
-            folder_name = _get_folder_name(row)
-            if folder_name:
-                processed_row["folder_name"] = folder_name
-
-        # Add asset type only if it can be determined
-        asset_type = _get_asset_type(row)
-        if asset_type:
-            processed_row["asset_type"] = asset_type
-
-        # For now, as final step before finishing with this row's data,
-        # be sure both file_name and folder_name are not set.  This may change in future,
-        # in which case this check should be done during a more appropriate earlier step.
-        if processed_row.get("file_name") and processed_row.get("folder_name"):
-            logger.warning(
-                "Both file_name and folder_name are set for DL record "
-                f"{processed_row.get("dl_record_id")}. Skipping row."
-            )
-            continue
-
-        # Also check if primary title ("title") is set, and skip if it is not.
-        if not processed_row.get("title"):
-            logger.warning(
-                f"Title must be set for Alma MMS ID {alma_mms_id}. Skipping row."
-            )
-            continue
-
-        processed_data.append(processed_row)
-
-    # Tedial requires all records be under one top-level key called "assets".
-    final_data = {"assets": processed_data}
-
-    # Save processed data to output JSON file.
-    _write_output_file(args.output_file, final_data)
-    logger.info(f"Processed data saved to {args.output_file}")
+    # Save processed data to separate output JSON files.
+    _write_output_file(Path(args.output_dir, "tracks.json"), track_data)
+    _write_output_file(Path(args.output_dir, "assets.json"), asset_data)
+    _get_logger().info(f"Processed data saved to '{args.output_dir}'")
 
 
 if __name__ == "__main__":
+    # Make logger available at module level.
+    # Otherwise, it's not available when running tests.
+    _get_logger()
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,6 @@
-# alma_api_client must be installed from the GitHub repository.
-# This also brings in pymarc, for MARC records.
-git+https://github.com/UCLALibrary/alma-api-client
+# Install `ftva-etl` package
+git+https://github.com/UCLALibrary/ftva-etl
+
 # For Excel conversion
 pandas==2.2.3
 openpyxl==3.1.5
-# for NLP
-spacy==3.7.5
-en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
-en_core_web_md @ https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.7.1/en_core_web_md-3.7.1-py3-none-any.whl
-# For Filemaker API access
-python-fmrest==1.7.5
-# For metadata extraction
-python-dateutil==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Install `ftva-etl` package
 git+https://github.com/UCLALibrary/ftva-etl
-
+xmltodict==0.14.2
 # For Excel conversion
 pandas==2.2.3
 openpyxl==3.1.5

--- a/tests/test_generate_metadata.py
+++ b/tests/test_generate_metadata.py
@@ -1,20 +1,17 @@
 import logging
 import unittest
-from pymarc import Field, Indicators, Record, Subfield
+from unittest.mock import Mock, patch
 from generate_metadata import (
-    _get_language_name,
-    _get_language_map,
-    _get_main_title_from_bib,
-    _get_alternative_titles_from_bib,
-    _get_series_title_from_bib,
-    _get_episode_title_from_bib,
-    _get_title_info,
-    _get_asset_type,
-    _get_file_name,
+    _get_uuid_by_record_id,
+    _process_input_data,
 )
+from pymarc.record import Record as BibRecord
+from fmrest.record import Record as FMRecord
 
 
 class TestGenerateMetadata(unittest.TestCase):
+    """Test the `generate_metadata` module."""
+
     def setUp(self):
         # Turn off logging for this test case, for all but CRITICAL
         # which we don't generally use.
@@ -22,280 +19,68 @@ class TestGenerateMetadata(unittest.TestCase):
         # methods being tested.
         logging.disable(level=logging.CRITICAL)
 
-        self.language_map = _get_language_map("language_map.json")
-        self.minimal_bib_record = self._get_minimal_bib_record()
-
-    def _get_minimal_bib_record(self) -> Record:
-        """Create a valid but minimal bib record with just 001 and 245 $a.
-        This will be used as the base record, then copied & modified
-        for other tests as needed.
-
-        :return record: Minimal bib record with just 001 and 245 fields.
-        """
-        field_001 = Field(tag="001", data="12345")
-        field_245 = Field(
-            tag="245",
-            indicators=Indicators("0", "0"),
-            subfields=[Subfield(code="a", value="F245a")],
-        )
-        record = Record()
-        record.add_field(field_001)
-        record.add_field(field_245)
-        return record
-
-    def _get_bib_record_bad_008(self) -> Record:
-        """Create a bib record with an invalid 008 field,
-        with bad data and incorrect length.
-
-        :return record: Minimal bib record with a bad 008 field.
-
-        """
-        bad_field_008 = Field(tag="008", data="xxxxxxxxxxxxxxxx")
-        record = self.minimal_bib_record
-        record.add_field(bad_field_008)
-        return record
-
-    def test_get_language_name_no_008(self):
-        # The minimal record has no 008 field.
-        record = self.minimal_bib_record
-        language_name = _get_language_name(record, self.language_map)
-        self.assertEqual(language_name, "")
-
-    def test_get_language_name_bad_008(self):
-        record = self._get_bib_record_bad_008()
-        language_name = _get_language_name(record, self.language_map)
-        self.assertEqual(language_name, "")
-
-    def test_get_language_name_invalid_code(self):
-        # The minimal record has no 008 field; add one with an invalid
-        # language code in positions 35-37.  Other data in the 008
-        # does not matter for this, so use spaces.
-
-        # A bib 008 field must have 40 characters.
-        spaces = " " * 40
-        # Set positions 35-37 to an invalid language code (not in the language map).
-        field_008_data = spaces[:35] + "BAD" + spaces[38:]
-        record = self.minimal_bib_record
-        # Add the bad 008 field
-        record.add_field(Field(tag="008", data=field_008_data))
-        language_name = _get_language_name(record, self.language_map)
-        self.assertEqual(language_name, "")
-
-    def test_get_language_name_valid_code(self):
-        # The minimal record has no 008 field; add one with a valid
-        # language code in positions 35-37.  Other data in the 008
-        # does not matter for this, so use spaces.
-
-        # A bib 008 field must have 40 characters.
-        spaces = " " * 40
-        # Set positions 35-37 to a valid language code (in the language map).
-        field_008_data = spaces[:35] + "fre" + spaces[38:]
-        record = self.minimal_bib_record
-        # Add the good 008 field
-        record.add_field(Field(tag="008", data=field_008_data))
-        language_name = _get_language_name(record, self.language_map)
-        self.assertEqual(language_name, "French")
-
-    def test_get_asset_type_raw(self):
-        item = {"file_name": "example_raw_file.mov"}
-        asset_type = _get_asset_type(item)
-        self.assertEqual(asset_type, "Raw")
-
-    def test_get_asset_type_intermediate(self):
-        item = {"file_name": "example_file_mti.mov"}
-        asset_type = _get_asset_type(item)
-        self.assertEqual(asset_type, "Intermediate")
-
-    def test_get_asset_type_final(self):
-        item = {"file_name": "example_file_final.mov"}
-        asset_type = _get_asset_type(item)
-        self.assertEqual(asset_type, "Final Version")
-
-    def test_get_asset_type_derivative(self):
-        item = {"file_name": "example_file_finals_finals.mov"}
-        asset_type = _get_asset_type(item)
-        self.assertEqual(asset_type, "Derivative")
-
-    def test_get_asset_type_unknown(self):
-        item = {"file_name": "example_file.mov"}
-        asset_type = _get_asset_type(item)
-        self.assertEqual(asset_type, "")
-
-    def test_get_asset_type_dpx_intermediate(self):
-        item = {"folder_name": "example_folder_MTI", "file_type": "DPX"}
-        asset_type = _get_asset_type(item)
-        self.assertEqual(asset_type, "Intermediate")
-
-    def test_get_asset_type_dpx_raw(self):
-        item = {"folder_name": "example_folder", "file_type": "DPX"}
-        asset_type = _get_asset_type(item)
-        self.assertEqual(asset_type, "Raw")
-
-    def test_get_main_title_minimal_record(self):
-        record = self.minimal_bib_record
-        main_title = _get_main_title_from_bib(record)
-        self.assertEqual(main_title, "F245a")
-
-    def test_get_alternative_titles_valid_indicators(self):
-        record = self.minimal_bib_record
-
-        # Valid indicators are 0 or 2 or 3 followed by whitespace
-        field_246_1 = Field(
-            tag="246",
-            indicators=Indicators("0", " "),
-            subfields=[
-                Subfield(code="a", value="foo"),
-            ],
-        )
-        field_246_2 = Field(
-            tag="246",
-            indicators=Indicators("2", " "),
-            subfields=[
-                Subfield(code="a", value="bar"),
-            ],
-        )
-        field_246_3 = Field(
-            tag="246",
-            indicators=Indicators("3", " "),
-            subfields=[
-                Subfield(code="a", value="baz"),
-            ],
-        )
-        record.add_field(field_246_1)
-        record.add_field(field_246_2)
-        record.add_field(field_246_3)
-        alternative_titles = _get_alternative_titles_from_bib(record)
-        self.assertListEqual(alternative_titles, ["foo", "bar", "baz"])
-
-    def test_get_alternative_titles_invalid_indicators(self):
-        record = self.minimal_bib_record
-
-        # Trying different invalid indicator combos
-        field_246_1 = Field(
-            tag="246",
-            indicators=Indicators("0", "1"),
-            subfields=[
-                Subfield(code="a", value="foo"),
-            ],
-        )
-        field_246_2 = Field(
-            tag="246",
-            indicators=Indicators("5", " "),
-            subfields=[
-                Subfield(code="a", value="bar"),
-            ],
-        )
-        field_246_3 = Field(
-            tag="246",
-            indicators=Indicators(" ", " "),
-            subfields=[
-                Subfield(code="a", value="baz"),
-            ],
-        )
-        record.add_field(field_246_1)
-        record.add_field(field_246_2)
-        record.add_field(field_246_3)
-        alternative_titles = _get_alternative_titles_from_bib(record)
-        self.assertListEqual(alternative_titles, [])
-
-    def test_get_series_title(self):
-        record = self.minimal_bib_record
-        field_245 = record.get("245")
-
-        main_title = record.get_fields("245")[0].get_subfields("a")[0]
-        series_subfield_codes = ["n", "p", "g"]  # g should result in ""
-        for code in series_subfield_codes:
-            with self.subTest(code=code):
-                if field_245:  # this is just to avoid linting errors
-                    field_245.add_subfield(code=code, value=f"F245{code}")
-                    series_title = _get_series_title_from_bib(record, main_title)
-                    # If 245 $n or 245 $p exists on record,
-                    # series title should be main title (245 $a),
-                    # else it should be an empty string.
-                    if code in ["n", "p"]:  #
-                        self.assertEqual(series_title, main_title)
-                    else:
-                        self.assertEqual(series_title, "")
-                    field_245.delete_subfield(code=code)
-
-    def test_get_episode_title(self):
-        record = self.minimal_bib_record
-        field_245 = record.get("245")
-        if field_245:  # to avoid linting error
-            field_245.add_subfield(code="n", value="Episode 001")
-            field_245.add_subfield(
-                code="p",
-                value="Pilot--unedited footage. Pam Jennings interviews Marlon Riggs",
-            )
-
-        field_246 = Field(tag="246", subfields=[Subfield(code="n", value="F246n")])
-        record.add_field(field_246)
-
-        episode_title = _get_episode_title_from_bib(record)
-
-        # Expected output comes from specs.
-        # Specs indicate that 245 $p should come first and be joined with 245 $n and 246 $n
-        # if they exist, using ". " as delimiter
-        expected_output = (
-            "Pilot--unedited footage. Pam Jennings interviews Marlon Riggs. "
-            "Episode 001. "
-            "F246n"
-        )
-        self.assertEqual(episode_title, expected_output)
-
-    def test_get_title_info(self):
-        # Testing the main coordinating function
-        # that calls all the smaller title-specific methods.
-
-        record = self.minimal_bib_record
-        field_245 = record.get("245")
-        if field_245:  # to avoid linting error
-            field_245.add_subfield(code="n", value="F245n")
-            field_245.add_subfield(code="p", value="F245p")
-
-        field_246_1 = Field(
-            tag="246",
-            indicators=Indicators("0", " "),  # indicators are valid
-            subfields=[
-                Subfield(code="a", value="F246a_1"),
-                Subfield(code="n", value="F246n_1"),
-            ],
-        )
-        field_246_2 = Field(
-            tag="246",
-            indicators=Indicators("2", " "),  # indicators are valid
-            subfields=[
-                Subfield(code="a", value="F246a_2"),
-                Subfield(code="n", value="F246n_2"),
-            ],
-        )
-        record.add_field(field_246_1, field_246_2)
-
-        expected_output = {
-            "title": "F245a F245p. F245n. F246n_1. F246n_2",
-            "series_title": "F245a",  # main title from minimal record
-            "alternative_titles": ["F246a_1", "F246a_2"],
-            "episode_title": "F245p. F245n. F246n_1. F246n_2",
+        # Create sample config file
+        self.sample_config = {
+            "filemaker": {"user": "test_user", "password": "test_password"},
+            "digital_data": {
+                "user": "dd_user",
+                "password": "dd_password",
+                "url": "http://test.example.com",
+            },
         }
-        titles = _get_title_info(record)
-        self.assertEqual(titles, expected_output)
 
-    def test_get_file_name_valid_extension(self):
-        item = {"file_name": "filename.wav"}
-        file_name = _get_file_name(item)
-        self.assertEqual(file_name, "filename")
+        # Create sample input CSV data
+        self.sample_input_data = [
+            {"dl_record_id": "123", "Audio Track?": "no", "match_asset": ""},
+            {"dl_record_id": "456", "Audio Track?": "yes", "match_asset": "789"},
+        ]
 
-    def test_get_file_name_invalid_extension(self):
-        item = {"file_name": "filename.XYZ"}
-        file_name = _get_file_name(item)
-        self.assertEqual(file_name, "filename.XYZ")
+        # Create sample BibRecord
+        self.sample_bib_record = BibRecord()
 
-    def test_get_file_name_multiple_extension(self):
-        item = {"file_name": "filename.something.wav"}
-        file_name = _get_file_name(item)
-        self.assertEqual(file_name, "filename.something")
+        # Create sample FMRecord
+        self.sample_fm_record = FMRecord([], [])
 
-    def test_get_file_name_no_extension(self):
-        item = {"file_name": "filename"}
-        file_name = _get_file_name(item)
-        self.assertEqual(file_name, "filename")
+        # Create sample DigitalDataRecord
+        self.sample_digital_data_record = {
+            "inventory_number": "123",
+            "uuid": "test-uuid-123",
+        }
+
+    @patch("generate_metadata.DigitalDataClient")
+    def test_get_uuid_by_record_id_success(self, mock_dd_client):
+        """Test successful UUID retrieval."""
+        mock_record = {"uuid": "test-uuid-123"}
+        mock_dd_client.return_value.get_record_by_id.return_value = mock_record
+
+        # It doesn't matter what the record ID is, only that it's an int.
+        # Mocking
+        uuid = _get_uuid_by_record_id(123, mock_dd_client.return_value)
+        self.assertEqual(uuid, "test-uuid-123")
+
+    def test_process_input_data(self):
+        """Test the `_process_input_data` function."""
+        # Mock the clients
+        alma_sru_client = Mock()
+        filemaker_client = Mock()
+        digital_data_client = Mock()
+
+        # Mock the return values of the clients
+        alma_sru_client.search_by_call_number.return_value = self.sample_bib_record
+        filemaker_client.search_by_inventory_number.return_value = self.sample_fm_record
+        digital_data_client.get_record_by_id.return_value = (
+            self.sample_digital_data_record
+        )
+
+        # Use the mocked clients, which return the sample records defined in `setUp`.
+        asset_data, track_data = _process_input_data(
+            self.sample_input_data,
+            alma_sru_client,
+            filemaker_client,
+            digital_data_client,
+        )
+
+        # These assertions are mostly placeholders.
+        # TODO: figure out how best to test actual sample data.
+        self.assertIsInstance(asset_data, list)
+        self.assertIsInstance(track_data, list)

--- a/tests/test_generate_metadata.py
+++ b/tests/test_generate_metadata.py
@@ -1,86 +1,8 @@
-import logging
 import unittest
-from unittest.mock import Mock, patch
-from generate_metadata import (
-    _get_uuid_by_record_id,
-    _process_input_data,
-)
-from pymarc.record import Record as BibRecord
-from fmrest.record import Record as FMRecord
 
 
 class TestGenerateMetadata(unittest.TestCase):
     """Test the `generate_metadata` module."""
 
-    def setUp(self):
-        # Turn off logging for this test case, for all but CRITICAL
-        # which we don't generally use.
-        # Otherwise, test output is cluttered with log messages from
-        # methods being tested.
-        logging.disable(level=logging.CRITICAL)
-
-        # Create sample config file
-        self.sample_config = {
-            "filemaker": {"user": "test_user", "password": "test_password"},
-            "digital_data": {
-                "user": "dd_user",
-                "password": "dd_password",
-                "url": "http://test.example.com",
-            },
-        }
-
-        # Create sample input CSV data
-        self.sample_input_data = [
-            {"dl_record_id": "123", "Audio Track?": "no", "match_asset": ""},
-            {"dl_record_id": "456", "Audio Track?": "yes", "match_asset": "789"},
-        ]
-
-        # Create sample BibRecord
-        self.sample_bib_record = BibRecord()
-
-        # Create sample FMRecord
-        self.sample_fm_record = FMRecord([], [])
-
-        # Create sample DigitalDataRecord
-        self.sample_digital_data_record = {
-            "inventory_number": "123",
-            "uuid": "test-uuid-123",
-        }
-
-    @patch("generate_metadata.DigitalDataClient")
-    def test_get_uuid_by_record_id_success(self, mock_dd_client):
-        """Test successful UUID retrieval."""
-        mock_record = {"uuid": "test-uuid-123"}
-        mock_dd_client.return_value.get_record_by_id.return_value = mock_record
-
-        # It doesn't matter what the record ID is, only that it's an int.
-        # Mocking
-        uuid = _get_uuid_by_record_id(123, mock_dd_client.return_value)
-        self.assertEqual(uuid, "test-uuid-123")
-
-    def test_process_input_data(self):
-        """Test the `_process_input_data` function."""
-        # Mock the clients
-        alma_sru_client = Mock()
-        filemaker_client = Mock()
-        digital_data_client = Mock()
-
-        # Mock the return values of the clients
-        alma_sru_client.search_by_call_number.return_value = self.sample_bib_record
-        filemaker_client.search_by_inventory_number.return_value = self.sample_fm_record
-        digital_data_client.get_record_by_id.return_value = (
-            self.sample_digital_data_record
-        )
-
-        # Use the mocked clients, which return the sample records defined in `setUp`.
-        asset_data, track_data = _process_input_data(
-            self.sample_input_data,
-            alma_sru_client,
-            filemaker_client,
-            digital_data_client,
-        )
-
-        # These assertions are mostly placeholders.
-        # TODO: figure out how best to test actual sample data.
-        self.assertIsInstance(asset_data, list)
-        self.assertIsInstance(track_data, list)
+    # TODO: Add tests, if necessary.
+    pass


### PR DESCRIPTION
Implements [SYS-1974](https://uclalibrary.atlassian.net/browse/SYS-1974)

### Acceptance criteria
- [x] The `generate_metadata.py` script is rewritten to use the new `ftva_etl` package
- [x] The script reads from the new [list of records](https://docs.google.com/spreadsheets/d/1LAbSnTm7YCvkJRrerJKReAvWKyrGKQYNkH-ZecN4FvM/edit?gid=0#gid=0) for the 25-50 pilot
- [x] Assets and track files are written separately
  - [x] The relationship between assets and tracks is obtained from the spreadsheet, via the “Audio track?” and “match_asset” columns

### Description
This PR reworks the `generate_metadata.py` module to use our `ftva_etl` package. The script accepts an input file in the form of a CSV export of the "DD Record IDs_Media to Ingest into MAMs" Google Sheet linked above and a TOML config file with API credentials. Using the "Audio Track?" column, the script separates tracks from assets and retrieves the UUID for match assets from the provided DD record ID. Lists of track and asset data are then written as separate JSON files to an output directory that can be configured via CLI arguments.

Utilizing the `ftva_etl` package required updating to Python 3.13 in the Dockerfile, and dependencies in `requirements.txt` that have been consolidated into `ftva_etl` were removed.

I made two small changes to the way the logger was previously handled:
1. made it write to a `logs` directory; and
2. declared it in the whole module scope, so that it is created during tests.

### Testing
I updated `test_generate_metadata.py` in such a way that our unit-test suite will still pass, but the tests are still WIPs. I experimented with the [unittest.mock](https://docs.python.org/3/library/unittest.mock.html) object library, so as to avoid calls to the actual APIs.

The tests are not so meaningful at this point; mostly just showing that the central `process_input_data` function returns lists for tracks and assets. I could set up sample records from the three data sources based on real records, then manipulate them to test different edge scenarios.

[SYS-1974]: https://uclalibrary.atlassian.net/browse/SYS-1974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ