### PR TITLE
DLSR-37: Update metadata generation script to work with 1-1 matches

### DIFF
--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -164,12 +164,23 @@ def _process_input_data(
             )
             inventory_number = digital_data_record["inventory_number"]
             # First get all results from Alma matching the inventory number
+            # There may not be any matches - if so, this is a "1-to-1" record,
+            # so we'll use only DD and FM data.
+            # Initialize bib_record variable first so we can check for it later.
+            bib_record = None
             all_bib_records = alma_sru_client.search_by_call_number(inventory_number)
-            # Then take the first record that matches the inventory number and is from FTVA library.
+            # Take the first record that matches the inventory number and is from FTVA library.
             # This prevents false matches from other libraries.
-            bib_record = filter_by_inventory_number_and_library(
+            bib_records = filter_by_inventory_number_and_library(
                 all_bib_records, inventory_number
-            )[0]
+            )
+            if bib_records:
+                bib_record = bib_records[0]
+            else:
+                logger.info(
+                    f"No Alma bib records found for inventory number '{inventory_number}' "
+                    f"on record {row['dl_record_id']}. Proceeding with DD and FM data only."
+                )
             filemaker_record = filemaker_client.search_by_inventory_number(
                 inventory_number
             )[0]
@@ -191,9 +202,20 @@ def _process_input_data(
                 )
                 continue
 
-        metadata_record = get_mams_metadata(
-            bib_record, filemaker_record, digital_data_record, match_asset_uuid
-        )
+        if bib_record:
+            metadata_record = get_mams_metadata(
+                digital_data_record,
+                filemaker_record,
+                bib_record,
+                match_asset_uuid,
+            )
+        else:
+            metadata_record = get_mams_metadata(
+                digital_data_record,
+                filemaker_record,
+                None,
+                match_asset_uuid,
+            )
 
         # Add temporary field for file_type to be used later for DPX splitting
         metadata_record["file_type"] = digital_data_record.get("file_type", "")

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -203,10 +203,10 @@ def _process_input_data(
                 continue
 
         metadata_record = get_mams_metadata(
-            digital_data_record,
-            filemaker_record,
-            bib_record,
-            match_asset_uuid,
+            digital_data_record=digital_data_record,
+            filemaker_record=filemaker_record,
+            bib_record=bib_record,
+            match_asset_uuid=match_asset_uuid,
         )
 
         # Add temporary field for file_type to be used later for DPX splitting

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -422,11 +422,7 @@ def main() -> None:
         for key, records in split_data.items():
             # Remove temporary 'file_type' field before output
             for record in records:
-                if record.get("file_type") not in [
-                    "DPX",
-                    "DCP",
-                ]:  # Keep `file_type` on DPX and DCP records
-                    record.pop("file_type", None)
+                record.pop("file_type", None)
             output_dict = {"media": {"assets": records}}
             filename = f"{output_filename_stem}_{key.replace(' ', '_')}.json"
             _write_output_file(Path(args.output_dir, filename), output_dict)
@@ -436,7 +432,11 @@ def main() -> None:
         metadata_records = _set_record_type(metadata_records)
         # Remove temporary 'file_type' field before output
         for record in metadata_records:
-            record.pop("file_type", None)
+            if record.get("file_type") not in [
+                "DPX",
+                "DCP",
+            ]:  # Keep `file_type` on DPX and DCP records
+                record.pop("file_type", None)
         output_dict = {"media": {"assets": metadata_records}}
         _write_output_file(
             Path(args.output_dir, f"{output_filename_stem}.json"), output_dict

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -422,7 +422,11 @@ def main() -> None:
         for key, records in split_data.items():
             # Remove temporary 'file_type' field before output
             for record in records:
-                record.pop("file_type", None)
+                if record.get("file_type") not in [
+                    "DPX",
+                    "DCP",
+                ]:  # Keep `file_type` on DPX and DCP records
+                    record.pop("file_type", None)
             output_dict = {"media": {"assets": records}}
             filename = f"{output_filename_stem}_{key.replace(' ', '_')}.json"
             _write_output_file(Path(args.output_dir, filename), output_dict)
@@ -432,11 +436,7 @@ def main() -> None:
         metadata_records = _set_record_type(metadata_records)
         # Remove temporary 'file_type' field before output
         for record in metadata_records:
-            if record.get("file_type") not in [
-                "DPX",
-                "DCP",
-            ]:  # Keep `file_type` on DPX and DCP records
-                record.pop("file_type", None)
+            record.pop("file_type", None)
         output_dict = {"media": {"assets": metadata_records}}
         _write_output_file(
             Path(args.output_dir, f"{output_filename_stem}.json"), output_dict

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -202,20 +202,12 @@ def _process_input_data(
                 )
                 continue
 
-        if bib_record:
-            metadata_record = get_mams_metadata(
-                digital_data_record,
-                filemaker_record,
-                bib_record,
-                match_asset_uuid,
-            )
-        else:
-            metadata_record = get_mams_metadata(
-                digital_data_record,
-                filemaker_record,
-                None,
-                match_asset_uuid,
-            )
+        metadata_record = get_mams_metadata(
+            digital_data_record,
+            filemaker_record,
+            bib_record,
+            match_asset_uuid,
+        )
 
         # Add temporary field for file_type to be used later for DPX splitting
         metadata_record["file_type"] = digital_data_record.get("file_type", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Install `ftva-etl` package
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.1.5
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.2.1
 xmltodict==0.14.2
 # For Excel conversion
 pandas==2.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Install `ftva-etl` package
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.2.1
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.3.0
 xmltodict==0.14.2
 # For Excel conversion
 pandas==2.2.3


### PR DESCRIPTION
[Implements DLSR-37](https://uclalibrary.atlassian.net/browse/DLSR-37)

**Must be merged AFTER [DSLR-153/DLSR-160](https://github.com/UCLALibrary/ftva-etl/pull/29)**

Updates `generate_metadata.py` to allow for use with 1-1 (DD-FM) matched records, in addition to existing 1-1-1 functionality. These changes are pretty simple, as actual data extraction and manipulation is handled in the `ftva-etl` package.

To test:
1. Use the `legacy_fm_changes` branch of the `ftva-etl` package. Edit `requirements.txt`, and change `git+https://github.com/UCLALibrary/ftva-etl.git@v0.1.5` to `git+https://github.com/UCLALibrary/ftva-etl.git@legacy_fm_changes`.
2. Create an input data file. The script wants a .csv, and only cares about the presence and values of columns called  `dl_record_id` and `Audio Track?`. In the current DD database, `23064` is an example `dl_record_id` with a 1-1-1 match, and `15883` is a 1-1.
3. Run the script: `python generate_metadata.py --config_file prod_config_secrets.toml --input_file sample.csv`

I did not update the automated tests. All 32 still pass: `python -m unittest`