### PR TITLE
DLSR-44: Batch updates for FM Language field

### DIFF
--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -2,6 +2,8 @@ import tomllib
 import logging
 import argparse
 import re
+from string import capwords
+from strsimpy.normalized_levenshtein import NormalizedLevenshtein
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
@@ -110,7 +112,7 @@ def _get_config(config_file_name: str) -> dict:
 # as the number of fields grows.
 # --------------------
 MAPPINGS = {
-    # NOTE: to smooth out casing inconsistencies,
+    # NOTE: for production_type values, to smooth out casing inconsistencies,
     # all values (except special cases) will be uppercased prior to mapping,
     # so keys need to be provided in uppercase here to ensure consistent mapping.
     # These mappings are intended to standardize variants of the same term into a controlled list,
@@ -126,7 +128,23 @@ MAPPINGS = {
         "FULL SILENT APERTURE 1.33:1": None,  # None means the value will be removed
         "SF": None,
         "SE": None,
-    }
+    },
+    "language": {
+        "Fr": "French",
+        "Ital": "Italian",
+        "Eng": "English",
+        "Portuguese for Brazil": "Portuguese",
+        "Unknown": "Undetermined",
+        "?": "Undetermined",
+        "": "Undetermined",  # TODO: does this capture NULLs?
+        "N/A": "No linguistic content",
+        "None": "No linguistic content",
+    },
+}
+
+FIELD_DELIMITERS = {
+    "production_type": "\r",
+    "language": ", ",
 }
 
 
@@ -160,6 +178,81 @@ def _make_uppercase(value: str) -> str:
     return value.upper() if value not in special_cases else value
 
 
+def _make_capitalized(value: str) -> str:
+    """Convert the provided value to capitalized case."""
+    return capwords(value)
+
+
+def _remove_intertitles(value: str) -> str:
+    """Remove "Intertitles" from the provided value, if present."""
+    return value.replace("Intertitles", "").strip()
+
+
+def _normalize_delimiters(value: str) -> str:
+    """Normalize delimiters in the provided value to comma and space (", ")."""
+    # Cases to normalize include: semicolons, slashes, "and", ampersands, \r,
+    # and improperly spaced commas.
+    return re.sub(r"\s*(?:[,;/]|and|&|\r)\s*", ", ", value)
+
+
+def _normalize_language_spelling(value: str) -> str:
+    """Attempt to normalize language spellings, e.g. "Gernan" -> "German"."""
+    valid_languages = [
+        "Amharic",
+        "Arabic",
+        "Chinese",
+        "Czech",
+        "Danish",
+        "Dutch",
+        "English",
+        "Ethiopic",
+        "French",
+        "German",
+        "Hebrew",
+        "Hindi",
+        "Hungarian",
+        "Indonesian",
+        "Italian",
+        "Japanese",
+        "Korean",
+        "Navajo",
+        "No linguistic content",
+        "Norwegian",
+        "Persian",
+        "Polish",
+        "Portuguese",
+        "Russian",
+        "Spanish",
+        "Swedish",
+        "Thai",
+        "Ukrainian",
+        "Undetermined",
+        "Vietnamese",
+        "Yupik languages",
+    ]
+    # Use normalized Levenshtein distance to find the closest valid language
+    levenshtein = NormalizedLevenshtein()
+    closest_language = None
+    closest_distance = float("inf")
+    for language in valid_languages:
+        distance = levenshtein.distance(value, language)
+        if distance < closest_distance:
+            closest_distance = distance
+            closest_language = language
+    # If the closest match is close enough, return it; else return original value
+    if closest_language is not None and closest_distance < 0.2:
+        if closest_language != value:
+            # Log the normalization decision, but only if a change is actually being made
+            logger.info(
+                f"Normalized language spelling: {value!r} -> {closest_language!r} "
+                f"(distance={closest_distance:.2f})"
+            )
+        return closest_language
+    else:
+        logger.info(f"No close match found for language: {value!r}. ")
+        return value
+
+
 # These list out the transformers to apply for each target field.
 # We can reuse generic transformers, but apply them in different orders if need be.
 TRANSFORMERS = {
@@ -171,42 +264,62 @@ TRANSFORMERS = {
         lambda value: MAPPINGS["production_type"].get(
             value, value
         ),  # Apply the mapping defined above
-    ]
+    ],
+    "language": [
+        _trim_whitespace,
+        _normalize_delimiters,
+        lambda value: MAPPINGS["language"].get(value, value),
+        _make_capitalized,
+        _normalize_language_spelling,
+        _dedupe_repeated_phrase,
+        _remove_intertitles,
+    ],
 }
 
 
-def _split_multivalue_field(value: str) -> list[str]:
-    """Split multivalue field (delimited by "\r" or ";") into a list of values."""
-    # Normalize delimiters to "\r"
-    value = value.replace(";", "\r")
-    return value.split("\r")
+def _split_multivalue_field(value: str, delimiter: str) -> list[str]:
+    """Split a multi-value field into a list of values, based on the provided delimiter.
+    Also trims whitespace from each value and filters out any empty values."""
+    if delimiter == ",":
+        # Normalize all possible delimiters to comma for language
+        value = re.sub(r"\s*(?:[,;/]|and|&|\r)\s*", ",", value)
+    else:
+        value = value.replace(";", delimiter)
+    return [v.strip() for v in value.split(delimiter)]
 
 
-def _rejoin_multivalue_field(values: list[str]) -> str:
-    """Rejoin list of values into a multivalue field (delimited by "\r"),
-    filtering out any Falsy values to avoid whitespace gaps in the final result.
-    """
-    return "\r".join(filter(None, values))
+def _rejoin_multivalue_field(values: list[str], delimiter: str) -> str:
+    """Rejoin list of values into a multivalue field, filtering out any Falsy values
+    to avoid whitespace gaps in the final result."""
+    # Remove duplicates and empty values
+    seen = set()
+    filtered = []
+    for v in values:
+
+        if v and v not in seen:
+            filtered.append(v)
+            seen.add(v)
+    return delimiter.join(filtered)
 
 
 def _apply_transformers(field_name: str, raw_value: str) -> str:
     """Apply transformers on the provided field,
     first splitting multi-value fields into a list of values,
     applying the transformers to each value individually,
-    then re-joining the results into a single string with the delimiter "\r",
-    because that's what Filemaker expects for multi-value fields.
+    then re-joining the results into a single string with the appropriate delimiter.
 
     :param field_name: The field name to transform.
     :param raw_value: The raw value to transform, possibly a multi-value field.
     :return: The transformed value.
     """
-    split_values = _split_multivalue_field(raw_value)
+    delimiter = FIELD_DELIMITERS.get(field_name, "\r")  # default to \r if not specified
+    split_values = _split_multivalue_field(raw_value, delimiter)
     transformed_values = []
     for value in split_values:
         for transformer in TRANSFORMERS[field_name]:
             value = transformer(value)
         transformed_values.append(value)
-    return _rejoin_multivalue_field(transformed_values)
+    return _rejoin_multivalue_field(transformed_values, delimiter)
 
 
 # --------------------

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -129,22 +129,21 @@ MAPPINGS = {
         "SF": None,
         "SE": None,
     },
-    "language": {
-        "Fr": "French",
-        "Ital": "Italian",
-        "Eng": "English",
-        "Portuguese for Brazil": "Portuguese",
-        "Unknown": "Undetermined",
+    "Language": {  # This key is capitalized to match FM field name
+        "fr": "French",  # These keys are all lowercase - transformers use .lower() for lookup
+        "eng": "English",
+        "portuguese for brazil": "Portuguese",
+        "unknown": "Undetermined",
         "?": "Undetermined",
-        "": "Undetermined",  # TODO: does this capture NULLs?
-        "N/A": "No linguistic content",
-        "None": "No linguistic content",
+        "": "Undetermined",
+        "n/a": "No linguistic content",
+        "none": "No linguistic content",
     },
 }
 
 FIELD_DELIMITERS = {
     "production_type": "\r",
-    "language": ", ",
+    "Language": ", ",
 }
 
 
@@ -186,13 +185,6 @@ def _make_capitalized(value: str) -> str:
 def _remove_intertitles(value: str) -> str:
     """Remove "Intertitles" from the provided value, if present."""
     return value.replace("Intertitles", "").strip()
-
-
-def _normalize_delimiters(value: str) -> str:
-    """Normalize delimiters in the provided value to comma and space (", ")."""
-    # Cases to normalize include: semicolons, slashes, "and", ampersands, \r,
-    # and improperly spaced commas.
-    return re.sub(r"\s*(?:[,;/]|and|&|\r)\s*", ", ", value)
 
 
 def _normalize_language_spelling(value: str) -> str:
@@ -243,13 +235,14 @@ def _normalize_language_spelling(value: str) -> str:
     if closest_language is not None and closest_distance < 0.2:
         if closest_language != value:
             # Log the normalization decision, but only if a change is actually being made
-            logger.info(
+            logger.debug(
                 f"Normalized language spelling: {value!r} -> {closest_language!r} "
                 f"(distance={closest_distance:.2f})"
             )
         return closest_language
     else:
-        logger.info(f"No close match found for language: {value!r}. ")
+        if value is not None and value.strip() != "":
+            logger.debug(f"No close match found for language: {value!r}. ")
         return value
 
 
@@ -265,14 +258,13 @@ TRANSFORMERS = {
             value, value
         ),  # Apply the mapping defined above
     ],
-    "language": [
+    "Language": [
         _trim_whitespace,
-        _normalize_delimiters,
-        lambda value: MAPPINGS["language"].get(value, value),
         _make_capitalized,
         _normalize_language_spelling,
         _dedupe_repeated_phrase,
         _remove_intertitles,
+        lambda value: MAPPINGS["Language"].get(value.lower(), value),
     ],
 }
 
@@ -280,9 +272,10 @@ TRANSFORMERS = {
 def _split_multivalue_field(value: str, delimiter: str) -> list[str]:
     """Split a multi-value field into a list of values, based on the provided delimiter.
     Also trims whitespace from each value and filters out any empty values."""
-    if delimiter == ",":
+    if delimiter == ", ":
         # Normalize all possible delimiters to comma for language
-        value = re.sub(r"\s*(?:[,;/]|and|&|\r)\s*", ",", value)
+        value = re.sub(r"\s*(?:[,;/|]|\band\b|&|\r)\s*", ", ", value)
+        logger.debug(f"Normalized delimiters to comma: {value!r}")
     else:
         value = value.replace(";", delimiter)
     return [v.strip() for v in value.split(delimiter)]

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -2,6 +2,7 @@ import tomllib
 import logging
 import argparse
 import re
+from enum import StrEnum
 from string import capwords
 from strsimpy.normalized_levenshtein import NormalizedLevenshtein
 from collections.abc import Iterator
@@ -141,10 +142,10 @@ MAPPINGS = {
     },
 }
 
-FIELD_DELIMITERS = {
-    "production_type": "\r",
-    "Language": ", ",
-}
+
+class FieldDelimiters(StrEnum):
+    production_type = "\r"
+    Language = ", "
 
 
 def _trim_whitespace(value: str) -> str:
@@ -222,6 +223,10 @@ def _normalize_language_spelling(value: str) -> str:
         "Vietnamese",
         "Yupik languages",
     ]
+    # First, make sure we have a non-empty string to compare against valid languages
+    # If not, return empty string which will eventually be mapped to "Undetermined"
+    if not value or value.strip() == "":
+        return ""
     # Use normalized Levenshtein distance to find the closest valid language
     levenshtein = NormalizedLevenshtein()
     closest_language = None
@@ -241,8 +246,7 @@ def _normalize_language_spelling(value: str) -> str:
             )
         return closest_language
     else:
-        if value is not None and value.strip() != "":
-            logger.debug(f"No close match found for language: {value!r}. ")
+        logger.debug(f"No close match found for language: {value!r}. ")
         return value
 
 
@@ -261,9 +265,9 @@ TRANSFORMERS = {
     "Language": [
         _trim_whitespace,
         _make_capitalized,
-        _normalize_language_spelling,
         _dedupe_repeated_phrase,
         _remove_intertitles,
+        _normalize_language_spelling,
         lambda value: MAPPINGS["Language"].get(value.upper(), value),
     ],
 }
@@ -272,7 +276,7 @@ TRANSFORMERS = {
 def _split_multivalue_field(value: str, delimiter: str) -> list[str]:
     """Split a multi-value field into a list of values, based on the provided delimiter.
     Also trims whitespace from each value and filters out any empty values."""
-    if delimiter == ", ":
+    if delimiter == FieldDelimiters["Language"].value:
         # Normalize all possible delimiters to comma for language
         value = re.sub(r"\s*(?:[,;/|]|\band\b|&|\r)\s*", ", ", value)
         logger.debug(f"Normalized delimiters to comma: {value!r}")
@@ -305,7 +309,7 @@ def _apply_transformers(field_name: str, raw_value: str) -> str:
     :param raw_value: The raw value to transform, possibly a multi-value field.
     :return: The transformed value.
     """
-    delimiter = FIELD_DELIMITERS.get(field_name, "\r")  # default to \r if not specified
+    delimiter = FieldDelimiters[field_name].value
     split_values = _split_multivalue_field(raw_value, delimiter)
     transformed_values = []
     for value in split_values:

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -112,7 +112,7 @@ def _get_config(config_file_name: str) -> dict:
 # as the number of fields grows.
 # --------------------
 MAPPINGS = {
-    # NOTE: for production_type values, to smooth out casing inconsistencies,
+    # NOTE: to smooth out casing inconsistencies,
     # all values (except special cases) will be uppercased prior to mapping,
     # so keys need to be provided in uppercase here to ensure consistent mapping.
     # These mappings are intended to standardize variants of the same term into a controlled list,
@@ -130,14 +130,14 @@ MAPPINGS = {
         "SE": None,
     },
     "Language": {  # This key is capitalized to match FM field name
-        "fr": "French",  # These keys are all lowercase - transformers use .lower() for lookup
-        "eng": "English",
-        "portuguese for brazil": "Portuguese",
-        "unknown": "Undetermined",
+        "FR": "French",
+        "ENG": "English",
+        "PORTUGUESE FOR BRAZIL": "Portuguese",
+        "UNKNOWN": "Undetermined",
         "?": "Undetermined",
         "": "Undetermined",
-        "n/a": "No linguistic content",
-        "none": "No linguistic content",
+        "N/A": "No linguistic content",
+        "NONE": "No linguistic content",
     },
 }
 
@@ -264,7 +264,7 @@ TRANSFORMERS = {
         _normalize_language_spelling,
         _dedupe_repeated_phrase,
         _remove_intertitles,
-        lambda value: MAPPINGS["Language"].get(value.lower(), value),
+        lambda value: MAPPINGS["Language"].get(value.upper(), value),
     ],
 }
 

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -54,6 +54,7 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             ("Englsh", "English"),  # misspelling
             ("German; English", "German, English"),  # semicolon delimiter
             ("French/German", "French, German"),  # slash delimiter
+            ("Italian | Spanish", "Italian, Spanish"),  # pipe delimiter
             ("Spanish and Italian", "Spanish, Italian"),  # "and" delimiter
             ("Chinese & Japanese", "Chinese, Japanese"),  # ampersand delimiter
             ("Russian,Italian", "Russian, Italian"),  # improperly spaced comma
@@ -72,5 +73,5 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
     def test_language_mapping(self):
         for input, expected in self.test_language_values:
             with self.subTest(input=input, expected=expected):
-                new_value = _apply_transformers("language", input)
+                new_value = _apply_transformers("Language", input)
                 self.assertEqual(new_value, expected)

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -48,9 +48,29 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
                 "TITLES, BKGD, Overlays",  # special case: "Overlays" keeps casing
             ),
         ]
+        self.test_language_values = [
+            ("english", "English"),
+            ("ENGLISH ", "English"),  # trailing whitespace
+            ("Englsh", "English"),  # misspelling
+            ("German; English", "German, English"),  # semicolon delimiter
+            ("French/German", "French, German"),  # slash delimiter
+            ("Spanish and Italian", "Spanish, Italian"),  # "and" delimiter
+            ("Chinese & Japanese", "Chinese, Japanese"),  # ampersand delimiter
+            ("Russian,Italian", "Russian, Italian"),  # improperly spaced comma
+            ("English; English", "English"),  # repeated language should be deduped
+            ("Portuguese for Brazil", "Portuguese"),  # special case, known value
+            ("?", "Undetermined"),  # special case, known value
+            ("Russian Intertitles", "Russian"),  # "Intertitles" should be removed
+        ]
 
     def test_production_type_mapping(self):
         for input, expected in self.test_production_type_values:
             with self.subTest(input=input, expected=expected):
                 new_value = _apply_transformers("production_type", input)
+                self.assertEqual(new_value, expected)
+
+    def test_language_mapping(self):
+        for input, expected in self.test_language_values:
+            with self.subTest(input=input, expected=expected):
+                new_value = _apply_transformers("language", input)
                 self.assertEqual(new_value, expected)


### PR DESCRIPTION
Implements [DLSR-44](https://uclalibrary.atlassian.net/browse/DLSR-244)

Specs: https://uclalibrary.atlassian.net/wiki/spaces/pm/pages/1734213643/language 

Adds functionality for batch Language normalization updates in FM. For a dry run (takes about 45 minutes for me): ```docker compose exec ftva_data python filemaker_batch_update.py -c prod_config_secrets.toml -f Language --dry_run```

Note the capital L in `Language` - for now, the script expects field names input on the command line to exactly match those in FM. 

New test cases are added for common Language normalization tasks, for a total of 33.

For @henry-r18's work: in addition to defining new `TRANSFORMER`s, this PR updates `_split_multivalue_field()` and `_rejoin_multivalue_field()` to use explicitly defined delimiters. These are managed in the variable `FIELD_DELIMITERS`. 

[DLSR-44]: https://uclalibrary.atlassian.net/browse/DLSR-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ