### PR TITLE
DLSR-269: catch Filemaker errors in batch update script

### DIFF
--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -426,7 +426,8 @@ def _process_record(
             # Log the error and continue processing other records
             logger.error(
                 f"Skipping record_id={record_id} inventory_id={inventory_id!r} "
-                f"due to Filemaker error: {e}"
+                f"due to Filemaker error: {e}. "
+                f"Pending changes were: {pending_changes}"
             )
             # Return 0 here to show that no changes were made
             return 0

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -418,14 +418,28 @@ def _process_record(
         pending_changes[field_name] = new_value
 
     if pending_changes and not dry_run:
-        success = fm_client.edit_record(record_id=record_id, field_data=pending_changes)
+        try:
+            success = fm_client.edit_record(
+                record_id=record_id, field_data=pending_changes
+            )
+        except FileMakerError as e:
+            # Log the error and continue processing other records
+            logger.error(
+                f"Skipping record_id={record_id} inventory_id={inventory_id!r} "
+                f"due to FileMaker error: {e}"
+            )
+            # Return 0 here to show that no changes were made
+            return 0
 
+        # fm_client.edit_record will return False if the update fails for a non-exception reason,
+        # so log that as well and return 0 to show that no changes were made
         if not success:
             logger.error(
                 f"Update failed for record_id={record_id} "
                 f"(inventory_id={inventory_id!r}). "
                 f"Filemaker last_error={fm_client._fms.last_error}"
             )
+            return 0
 
     return len(pending_changes)
 

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -462,6 +462,7 @@ def _process_batch(
         "records_processed": 0,
         "records_updated": 0,
         "total_changes_applied": 0,
+        "updates_failed": 0,
     }
     fields_validated = False
 
@@ -478,6 +479,8 @@ def _process_batch(
         if change_count > 0:
             stats["records_updated"] += 1
             stats["total_changes_applied"] += change_count
+        elif change_count == 0 and not dry_run:
+            stats["updates_failed"] += 1
 
     return stats
 
@@ -520,6 +523,8 @@ def main() -> None:
         f"{action} {stats['records_updated']} record(s) "
         f"with {stats['total_changes_applied']} total field change(s)."
     )
+    if stats["updates_failed"] > 0:
+        logger.warning(f"{stats['updates_failed']} record update(s) failed.")
 
 
 if __name__ == "__main__":

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -426,12 +426,12 @@ def _process_record(
             # Log the error and continue processing other records
             logger.error(
                 f"Skipping record_id={record_id} inventory_id={inventory_id!r} "
-                f"due to FileMaker error: {e}"
+                f"due to Filemaker error: {e}"
             )
             # Return 0 here to show that no changes were made
             return 0
 
-        # fm_client.edit_record will return False if the update fails for a non-exception reason,
+        # fm_client.edit_record will return False if the update fails without raising an exception,
         # so log that as well and return 0 to show that no changes were made
         if not success:
             logger.error(


### PR DESCRIPTION
Implements [DLSR-269](https://uclalibrary.atlassian.net/browse/DLSR-269)

Updates `filemaker_batch_update.py` to continue processing if a `FileMakerError` occurs when updating a record. This is done with a try-except block in `_process_record()`. For now, I'm catching all `FileMakerError`s, not just the error 509 I saw recently - given the large batches processed by this script, I think it makes sense to deal with other errors in this way too.

I also made a small change to the value returned by `_process_record()`, which is used for reporting statistics. If an update fails, this will not count toward the total number of updated records.

Testing: 33 automated tests still pass (`docker compose exec ftva_data python -m unittest`). The code updated in this PR only executes when data is actually updated, so running with the `--dry_run` flag is not relevant.

[DLSR-269]: https://uclalibrary.atlassian.net/browse/DLSR-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ