### PR TITLE
DLSR-245: Batch update `director`

### DIFF
--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -17,7 +17,7 @@ from fmrest.record import Record
 logger = logging.getLogger(Path(__file__).stem)
 
 # These are delimiter variations used in Filemaker multi-value fields
-FM_DELIMITER_PATTERN = r"\s*(?:[,;/|]|\band\b|&|\r)\s*"
+FM_DELIMITER_PATTERN = r"\s*([,;/|]|\band\b|&|\r)\s*"
 
 
 # --------------------
@@ -435,7 +435,11 @@ def _split_multivalue_field(
     :param delimiter: The delimiter to split on.
     :return: A list of individual values, and a boolean indicating whether to skip transformers.
     """
-    value = value.strip()
+    # Strip leading and trailing whitespace,
+    # then also strip any leadin or trailing
+    # delimiter characters defined for the field.
+    # This prevents bad delimiters from being included in output values.
+    value = value.strip().strip(delimiter)
     if not value:
         return [""], False
 

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -16,6 +16,39 @@ from fmrest.record import Record
 # handlers are configured via `_configure_logging`.
 logger = logging.getLogger(Path(__file__).stem)
 
+# These are delimiter variations used in Filemaker multi-value fields
+FM_DELIMITER_PATTERN = r"\s*(?:[,;/|]|\band\b|&|\r)\s*"
+
+DIRECTOR_NAME_PARTICLES = (
+    "de",
+    "la",
+    "le",
+    "du",
+    "des",
+    "van",
+    "von",
+    "ver",
+    "ten",
+    "ter",
+    "den",
+    "der",
+    "da",
+    "di",
+    "del",
+    "della",
+    "delle",
+    "degli",
+    "dell",
+    "dos",
+    "das",
+    "do",
+    "el",
+    "al",
+    "los",
+    "las",
+    "y",
+)
+
 
 # --------------------
 # Helper functions
@@ -140,12 +173,20 @@ MAPPINGS = {
         "N/A": "No linguistic content",
         "NONE": "No linguistic content",
     },
+    "director": {
+        "NO DIRECTOR LISTED": "N/A",
+        "N/A": "N/A",
+        "NULL": "Unknown",
+        "UNKNOWN": "Unknown",
+        "": "Unknown",
+    },
 }
 
 
 class FieldDelimiters(StrEnum):
     production_type = "\r"
     Language = ", "
+    director = ", "
 
 
 def _trim_whitespace(value: str) -> str:
@@ -181,6 +222,86 @@ def _make_uppercase(value: str) -> str:
 def _make_capitalized(value: str) -> str:
     """Convert the provided value to capitalized case."""
     return capwords(value)
+
+
+def _is_initials_token(token: str) -> bool:
+    """True if token is only single-letter initials separated by dots (e.g. A.B. or c.d.e.)."""
+    compact = token.replace(" ", "")
+    if not compact or not all(c.isalpha() or c == "." for c in compact):
+        return False
+    segments = [s for s in compact.split(".") if s]
+    return bool(segments) and all(len(s) == 1 and s.isalpha() for s in segments)
+
+
+def _format_initials(token: str) -> str:
+    """Normalize an initials token to the form A.B.C."""
+    letters = [c for c in token if c.isalpha()]
+    return ".".join(c.upper() for c in letters) + "."
+
+
+def _standardize_name_token(raw: str, word_index: int, n_words: int) -> str:
+    """Apply per-token rules inside one whitespace-delimited word (hyphens preserved)."""
+    hyphen_chunks = raw.split("-")
+    out_chunks = []
+    for chunk in hyphen_chunks:
+        if _is_initials_token(chunk):
+            out_chunks.append(_format_initials(chunk))
+        elif (
+            n_words > 1
+            and 0 < word_index < n_words - 1
+            and len(hyphen_chunks) == 1
+            and chunk.lower() in DIRECTOR_NAME_PARTICLES
+        ):
+            out_chunks.append(chunk.lower())
+        else:
+            out_chunks.append(chunk.capitalize())
+    return "-".join(out_chunks)
+
+
+def _standardize_director_name(name: str) -> str:
+    """Return a standardized format for director names, according to specs:
+
+    - Initials stay uppercase with dots between letters (e.g. A.B., C.D.E.).
+    - Common particles between first and last name stay lowercase (e.g. de la, van der).
+    - All other word parts use simple title case.
+
+    :param name: Raw name string.
+    :return: Standardized name string.
+    """
+    words = name.split()
+    n = len(words)
+    return " ".join(_standardize_name_token(w, i, n) for i, w in enumerate(words))
+
+
+def _parse_credited_names(value: str) -> str:
+    """Parse credited names from the provided value, according to specs:
+
+    - Use name following "as", e.g. Lew Landers (as Louis Friedlander) -> Louis Friedlander
+    - Use name before "i.e.", e.g. William Goodrich [i.e. Roscoe Arbuckle] -> William Goodrich
+    - Use name before "aka", e.g. Marcus aka Sid Marcus -> Marcus
+    - Note that "i.e." is normalized in `_split_multivalue_field` to avoid splitting on the comma
+
+    :param value: Raw value string.
+    :return: Parsed credited names string.
+    """
+    # Remove square brackets and parentheses and lowercase the value
+    value = re.sub(r"[\[\]\(\)]", "", value.lower())
+
+    if " as " in value:
+        parts = value.split(" as ")
+        if len(parts) == 2:
+            return parts[1].strip()
+
+    if "i.e." in value:
+        parts = value.split(" i.e. ")
+        if len(parts) == 2:
+            return parts[0].strip()
+
+    if " aka " in value:
+        parts = value.split(" aka ")
+        if len(parts) == 2:
+            return parts[0].strip()
+    return value
 
 
 def _remove_intertitles(value: str) -> str:
@@ -270,27 +391,62 @@ TRANSFORMERS = {
         _normalize_language_spelling,
         lambda value: MAPPINGS["Language"].get(value.upper(), value),
     ],
+    "director": [
+        _trim_whitespace,
+        _parse_credited_names,
+        _standardize_director_name,
+        lambda value: MAPPINGS["director"].get(value.upper(), value),
+    ],
 }
 
 
-def _split_multivalue_field(value: str, delimiter: str) -> list[str]:
-    """Split a multi-value field into a list of values, based on the provided delimiter.
-    Also trims whitespace from each value and filters out any empty values."""
-    if delimiter == FieldDelimiters["Language"].value:
-        # First, check for the known value "N/A.
-        # If present, replace with "NONE" and process as usual,
-        # which will eventually be mapped to "No linguistic content" by the mapping function.
-        if "N/A" in value:
-            logger.debug(
-                "Found known value 'N/A' in language field; replacing with 'NONE'."
-            )
-            value = value.replace("N/A", "NONE")
-        # Normalize all possible delimiters to comma for language
-        value = re.sub(r"\s*(?:[,;/|]|\band\b|&|\r)\s*", ", ", value)
-        logger.debug(f"Normalized delimiters to comma: {value!r}")
+def _normalize_multivalue_delimiters(value: str, delimiter: str) -> str:
+    """Normalize the delimiters in the provided value to the provided delimiter."""
+    new_value = re.sub(FM_DELIMITER_PATTERN, delimiter, value)
+    logger.debug(f"Normalized delimiters: {value!r} -> {new_value!r}")
+    return new_value
+
+
+def _split_multivalue_field(
+    field_name: str, value: str, delimiter: str
+) -> tuple[list[str], bool]:
+    """Splits a multi-value field into a list of values, based on the provided delimiter.
+    Also trims whitespace from each value and filters out any empty values.
+
+    Also returns a boolean indicating whether to skip transformers,
+    to preserve values as-is for certain fields.
+
+    :param field_name: The field name, for special handling of certain fields.
+    :param value: The input value to split.
+    :param delimiter: The delimiter to split on.
+    :return: A list of individual values, and a boolean indicating whether to skip transformers.
+    """
+    value = value.strip()
+    if not value:
+        return [""], False
+
+    # Handle special cases
+    if field_name == "Language":
+        # Normalize FM delimiters to comma for language
+        value = _normalize_multivalue_delimiters(value, delimiter)
+    elif field_name == "director":
+        exclusions = ["N/A"]  # Slash in N/A is not a delimiter
+        if value.upper() in exclusions:
+            # Exclusions should not have delimiters changes, but should still be transformed
+            return [value], False
+        # Normalize "i.e.," to "i.e." before delimiter normalization
+        # so that commas in "i.e.," are not counted as delimiters
+        value = re.sub(r"i\.\s*e\.\s*,", "i.e.", value, flags=re.IGNORECASE)
+        matches = re.findall(FM_DELIMITER_PATTERN, value)
+        if len(set(matches)) > 1:
+            # If multiple delimiter types are found,
+            # return value as-is and skip transformers.
+            return [value], True
+        value = _normalize_multivalue_delimiters(value, delimiter)
+    # Default to normalizing semicolons with delimiter
     else:
         value = value.replace(";", delimiter)
-    return [v.strip() for v in value.split(delimiter)]
+    return [v.strip() for v in value.split(delimiter)], False
 
 
 def _rejoin_multivalue_field(values: list[str], delimiter: str) -> str:
@@ -300,7 +456,6 @@ def _rejoin_multivalue_field(values: list[str], delimiter: str) -> str:
     seen = set()
     filtered = []
     for v in values:
-
         if v and v not in seen:
             filtered.append(v)
             seen.add(v)
@@ -318,7 +473,14 @@ def _apply_transformers(field_name: str, raw_value: str) -> str:
     :return: The transformed value.
     """
     delimiter = FieldDelimiters[field_name].value
-    split_values = _split_multivalue_field(raw_value, delimiter)
+    split_values, skip_transforms = _split_multivalue_field(
+        field_name, raw_value, delimiter
+    )
+    # Values in some fields require no transforms, aside from trimming whitespace,
+    # which is handled by the `_split_multivalue_field` function.
+    # If `skip_transforms` is True, there should be only one trimmed value in the list.
+    if skip_transforms:
+        return split_values[0] if split_values else ""
     transformed_values = []
     for value in split_values:
         for transformer in TRANSFORMERS[field_name]:

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -231,15 +231,6 @@ def _standardize_director_name(name: str) -> str:
         for chunk in name.split("-"):
             name = name.replace(chunk, capwords(chunk))
 
-    # Handle capitalization of initials.
-    formatted_chunks = []
-    for chunk in name.split():
-        if _is_initials_chunk(chunk):
-            formatted_chunks.append(_format_initials(chunk))
-            continue
-        formatted_chunks.append(chunk)
-    name = " ".join(formatted_chunks)
-
     # Address capitalization issue with nicknames,
     # e.g. prevent output of "Rosco 'fatty' Arbuckle",
     # due to `capwords` interpreting quote as first letter in nickname.
@@ -273,6 +264,15 @@ def _standardize_director_name(name: str) -> str:
         lambda m: f"{m.group(1)} {capwords(m.group(2))}",
         name,
     )
+
+    # Handle capitalization of initials after other transformations are applied.
+    formatted_chunks = []
+    for chunk in name.split():
+        if _is_initials_chunk(chunk):
+            formatted_chunks.append(_format_initials(chunk))
+            continue
+        formatted_chunks.append(chunk)
+    name = " ".join(formatted_chunks)
     return name
 
 

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -410,7 +410,8 @@ TRANSFORMERS = {
 
 def _normalize_multivalue_delimiters(value: str, delimiter: str) -> str:
     """Normalize the delimiters in the provided value to the provided delimiter."""
-    new_value = re.sub(FM_DELIMITER_PATTERN, delimiter, value)
+    # Case-insensitive to catch both " and " and " AND " delimiters
+    new_value = re.sub(FM_DELIMITER_PATTERN, delimiter, value, flags=re.IGNORECASE)
     if new_value != value:
         logger.debug(f"Normalized delimiters: {value!r} -> {new_value!r}")
     return new_value

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -19,36 +19,6 @@ logger = logging.getLogger(Path(__file__).stem)
 # These are delimiter variations used in Filemaker multi-value fields
 FM_DELIMITER_PATTERN = r"\s*(?:[,;/|]|\band\b|&|\r)\s*"
 
-DIRECTOR_NAME_PARTICLES = (
-    "de",
-    "la",
-    "le",
-    "du",
-    "des",
-    "van",
-    "von",
-    "ver",
-    "ten",
-    "ter",
-    "den",
-    "der",
-    "da",
-    "di",
-    "del",
-    "della",
-    "delle",
-    "degli",
-    "dell",
-    "dos",
-    "das",
-    "do",
-    "el",
-    "al",
-    "los",
-    "las",
-    "y",
-)
-
 
 # --------------------
 # Helper functions
@@ -262,9 +232,13 @@ def _standardize_director_name(name: str) -> str:
             name = name.replace(chunk, capwords(chunk))
 
     # Handle capitalization of initials.
+    formatted_chunks = []
     for chunk in name.split():
         if _is_initials_chunk(chunk):
-            name = name.replace(chunk, _format_initials(chunk))
+            formatted_chunks.append(_format_initials(chunk))
+            continue
+        formatted_chunks.append(chunk)
+    name = " ".join(formatted_chunks)
 
     # Address capitalization issue with nicknames,
     # e.g. prevent output of "Rosco 'fatty' Arbuckle",
@@ -313,23 +287,32 @@ def _parse_credited_names(value: str) -> str:
     :param value: Raw value string.
     :return: Parsed credited names string.
     """
-    # Remove square brackets and parentheses and lowercase the value
-    lower = re.sub(r"[\[\]\(\)]", "", value.lower())
+    # Use name following "as", accounting for possible parens or brackets
+    match_as = re.search(
+        r"(?:\(|\[)?"  # non-capturing group for possible opening paren or bracket
+        r"\bas\b\s*([^\)\]]+)"  # capture name after "as" (excluding closing paren or bracket)
+        r"(?:\)|\])?",  # non-capturing group for possible closing paren or bracket
+        value,
+        re.IGNORECASE,
+    )
+    if match_as:
+        name = match_as.group(1).strip()
+        if name:
+            return name
 
-    if " as " in lower:
-        parts = lower.split(" as ")
-        if len(parts) == 2:
-            return parts[1].strip()
+    # Use name before "i.e." or "aka", accounting for possible parens or brackets
+    match_ie_aka = re.search(
+        r"(.*?)\s+"  # capture group for name, follwed by 1 or more spaces
+        r"(?:\(|\[)?"  # non-capturing group for possible opening paren or bracket
+        r"(?:i\.e\.|aka)",  # non-capturing group for "i.e." or "aka"
+        value,
+        re.IGNORECASE,
+    )
+    if match_ie_aka:
+        name = match_ie_aka.group(1).strip()
+        if name:
+            return name
 
-    if "i.e." in lower:
-        parts = lower.split(" i.e. ")
-        if len(parts) == 2:
-            return parts[0].strip()
-
-    if " aka " in lower:
-        parts = lower.split(" aka ")
-        if len(parts) == 2:
-            return parts[0].strip()
     return value
 
 
@@ -461,20 +444,23 @@ def _split_multivalue_field(
         # Normalize FM delimiters to comma for language
         value = _normalize_multivalue_delimiters(value, delimiter)
     elif field_name == "director":
-        exclusions = ["N/A"]  # Slash in N/A is not a delimiter
-        if value.upper() in exclusions:
-            # Exclusions should not have delimiters changed, but should still be transformed
+        # If value contains "n/a" or "c/o" (case-insensitive),
+        # return value as-is, but do not skip transformers.
+        if re.search(r"(n/a|c/o)", value, flags=re.IGNORECASE):
             return [value], False
+
         # Normalize "i.e.," to "i.e." before delimiter normalization
         # so that commas in "i.e.," are not counted as delimiters
         value = re.sub(r"i\.\s*e\.\s*,", "i.e.", value, flags=re.IGNORECASE)
+
         # Handle cases where right parenthesis `)` is followed by an uppercase letter,
         # inserting a comma and space between them.
         value = re.sub(r"\)[A-Z]", lambda m: f"{m[0][:1]}, {m[0][1:]}", value)
+
+        # If multiple delimiter types are found,
+        # return value as-is and skip transformers.
         matches = re.findall(FM_DELIMITER_PATTERN, value)
         if len(set(matches)) > 1:
-            # If multiple delimiter types are found,
-            # return value as-is and skip transformers.
             return [value], True
         value = _normalize_multivalue_delimiters(value, delimiter)
     # Default to normalizing semicolons with delimiter
@@ -577,12 +563,13 @@ def _get_all_records(fm_client: FilemakerClient, page_size: int) -> Iterator[Rec
             offset=offset,
             limit=page_size,
         )
-        logger.info(f"Retrieved records {offset} to {offset + len(records) - 1}...")
 
-        # After final page reached, keep checking for records until iterator is exhausted
+        # Empty records list indicates end of pagination.
         if not records:
+            logger.info("Pagination complete. All records retrieved.")
             return
 
+        logger.info(f"Retrieved records {offset} to {offset + len(records) - 1}...")
         yield from records
         offset += page_size
 

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -224,61 +224,82 @@ def _make_capitalized(value: str) -> str:
     return capwords(value)
 
 
-def _is_initials_token(token: str) -> bool:
-    """True if token is only single-letter initials separated by dots (e.g. A.B. or c.d.e.)."""
-    compact = token.replace(" ", "")
-    if not compact or not all(c.isalpha() or c == "." for c in compact):
+def _is_initials_chunk(chunk: str) -> bool:
+    """True if the chunk is only single-letter initials separated by dots (e.g. A.B. or c.d.e.).
+
+    :param chunk: The chunk to check.
+    :return: True if the chunk is only single-letter initials separated by dots, False otherwise.
+    """
+    # Must be a non-empty string and only contain letters or dots
+    if not chunk or not all(c.isalpha() or c == "." for c in chunk):
         return False
-    segments = [s for s in compact.split(".") if s]
+    # Split on dots and check that each segment is a single letter
+    segments = [s for s in chunk.split(".") if s]
+    # Must be at least one segment and each segment must be a single letter
     return bool(segments) and all(len(s) == 1 and s.isalpha() for s in segments)
 
 
-def _format_initials(token: str) -> str:
-    """Normalize an initials token to the form A.B.C."""
-    letters = [c for c in token if c.isalpha()]
-    return ".".join(c.upper() for c in letters) + "."
+def _format_initials(chunk: str) -> str:
+    """Format an initials chunk to all-uppercase, e.g. a.b.c. -> A.B.C.
 
-
-def _standardize_name_token(raw: str, word_index: int, n_words: int) -> str:
-    """Apply per-token rules inside one whitespace-delimited word (hyphens preserved)."""
-    hyphen_chunks = raw.split("-")
-    out_chunks = []
-    for chunk in hyphen_chunks:
-        if _is_initials_token(chunk):
-            out_chunks.append(_format_initials(chunk))
-        elif (
-            n_words > 1  # only if more than one word in the name
-            and 0 < word_index < n_words - 1  # look at words between first and last
-            and len(hyphen_chunks) == 1  # only one chunk if no hyphens
-            and chunk.lower() in DIRECTOR_NAME_PARTICLES  # only if particle
-        ):  # special case: keep particles between first and last name lowercase
-            out_chunks.append(chunk.lower())
-        # special case: return surnames like "MacDonald" and "LeRoy" as-is.
-        elif (
-            not chunk.isupper()  # not completely uppercase
-            and len(chunk) > 2  # must be at least 3 characters
-            # must have at least 2 uppercase letters
-            and sum(1 for c in chunk if c.isupper()) >= 2
-        ):
-            out_chunks.append(chunk)
-        else:
-            out_chunks.append(chunk.capitalize())
-    return "-".join(out_chunks)
+    :param chunk: The chunk to format.
+    :return: The formatted initials chunk.
+    """
+    letters = [c for c in chunk if c.isalpha()]
+    return ".".join(c.upper() for c in letters) + "."  # add trailing dot
 
 
 def _standardize_director_name(name: str) -> str:
-    """Return a standardized format for director names, according to specs:
+    """Return a standardized form for director names, based on specs.
 
-    - Initials stay uppercase with dots between letters (e.g. A.B., C.D.E.).
-    - Common particles between first and last name stay lowercase (e.g. de la, van der).
-    - All other word parts use simple title case.
-
-    :param name: Raw name string.
-    :return: Standardized name string.
+    :param name: Raw input name string.
+    :return: Standardized output name string.
     """
-    words = name.split()
-    n = len(words)
-    return " ".join(_standardize_name_token(w, i, n) for i, w in enumerate(words))
+    # Apply capwords to fully uppercased or fully lowercased names,
+    # handling proper casing of hyphenated chunks.
+    if name.isupper() or name.islower():
+        for chunk in name.split("-"):
+            name = name.replace(chunk, capwords(chunk))
+
+    # Handle capitalization of initials.
+    for chunk in name.split():
+        if _is_initials_chunk(chunk):
+            name = name.replace(chunk, _format_initials(chunk))
+
+    # Address capitalization issue with nicknames,
+    # e.g. prevent output of "Rosco 'fatty' Arbuckle",
+    # due to `capwords` interpreting quote as first letter in nickname.
+    # NOTE: Output nicknames all wrapped in double-quotes.
+    name = re.sub(r"[\'\"](.*)[\'\"]", lambda m: f'"{capwords(m.group(1))}"', name)
+
+    # Roman numeral regex adapted from @https://stackoverflow.com/a/267405.
+    # It looks for numerals I through IX in a case-insensitive manner,
+    # (but not just X, to avoid matching e.g. "Malcolm X"),
+    # asserting the numerals have a word boundary before them,
+    # and are at the end of the string.
+    name = re.sub(
+        r"\b(?=[XVI])(IX|IV|V?I{0,3})$",
+        lambda m: m.group(0).upper(),
+        name,
+        flags=re.IGNORECASE,
+    )
+
+    # Special token (i.e. substring) "c/o" should be kept as-is, case-insensitive.
+    # Regex looks for "c/o" with word boundaries on either side in a case-insensitive manner.
+    name = re.sub(r"\bc/o\b", "c/o", name, flags=re.IGNORECASE)
+
+    # Handle issue with capitalizing numbered names, e.g. `1.brad Bird` -> `1. Brad Bird`.
+    # Regex looks for 1 or more digits followed by a dot,
+    # followed by 0 or more spaces, followed by any characters.
+    # The first group is the digits and dot, the second group is the rest of the string.
+    # We want to make sure the second group is capitalized correctly,
+    # and normalize the space between the groups.
+    name = re.sub(
+        r"(\d+\.)\s*(.+)",
+        lambda m: f"{m.group(1)} {capwords(m.group(2))}",
+        name,
+    )
+    return name
 
 
 def _parse_credited_names(value: str) -> str:
@@ -442,11 +463,14 @@ def _split_multivalue_field(
     elif field_name == "director":
         exclusions = ["N/A"]  # Slash in N/A is not a delimiter
         if value.upper() in exclusions:
-            # Exclusions should not have delimiters changes, but should still be transformed
+            # Exclusions should not have delimiters changed, but should still be transformed
             return [value], False
         # Normalize "i.e.," to "i.e." before delimiter normalization
         # so that commas in "i.e.," are not counted as delimiters
         value = re.sub(r"i\.\s*e\.\s*,", "i.e.", value, flags=re.IGNORECASE)
+        # Handle cases where right parenthesis `)` is followed by an uppercase letter,
+        # inserting a comma and space between them.
+        value = re.sub(r"\)[A-Z]", lambda m: f"{m[0][:1]}, {m[0][1:]}", value)
         matches = re.findall(FM_DELIMITER_PATTERN, value)
         if len(set(matches)) > 1:
             # If multiple delimiter types are found,
@@ -456,7 +480,8 @@ def _split_multivalue_field(
     # Default to normalizing semicolons with delimiter
     else:
         value = value.replace(";", delimiter)
-    return [v.strip() for v in value.split(delimiter)], False
+    # Use list(filter(None, ...)) to filter out any empty values from the split list.
+    return [v.strip() for v in list(filter(None, value.split(delimiter)))], False
 
 
 def _rejoin_multivalue_field(values: list[str], delimiter: str) -> str:

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -247,12 +247,20 @@ def _standardize_name_token(raw: str, word_index: int, n_words: int) -> str:
         if _is_initials_token(chunk):
             out_chunks.append(_format_initials(chunk))
         elif (
-            n_words > 1
-            and 0 < word_index < n_words - 1
-            and len(hyphen_chunks) == 1
-            and chunk.lower() in DIRECTOR_NAME_PARTICLES
-        ):
+            n_words > 1  # only if more than one word in the name
+            and 0 < word_index < n_words - 1  # look at words between first and last
+            and len(hyphen_chunks) == 1  # only one chunk if no hyphens
+            and chunk.lower() in DIRECTOR_NAME_PARTICLES  # only if particle
+        ):  # special case: keep particles between first and last name lowercase
             out_chunks.append(chunk.lower())
+        # special case: return surnames like "MacDonald" and "LeRoy" as-is.
+        elif (
+            not chunk.isupper()  # not completely uppercase
+            and len(chunk) > 2  # must be at least 3 characters
+            # must have at least 2 uppercase letters
+            and sum(1 for c in chunk if c.isupper()) >= 2
+        ):
+            out_chunks.append(chunk)
         else:
             out_chunks.append(chunk.capitalize())
     return "-".join(out_chunks)
@@ -285,20 +293,20 @@ def _parse_credited_names(value: str) -> str:
     :return: Parsed credited names string.
     """
     # Remove square brackets and parentheses and lowercase the value
-    value = re.sub(r"[\[\]\(\)]", "", value.lower())
+    lower = re.sub(r"[\[\]\(\)]", "", value.lower())
 
-    if " as " in value:
-        parts = value.split(" as ")
+    if " as " in lower:
+        parts = lower.split(" as ")
         if len(parts) == 2:
             return parts[1].strip()
 
-    if "i.e." in value:
-        parts = value.split(" i.e. ")
+    if "i.e." in lower:
+        parts = lower.split(" i.e. ")
         if len(parts) == 2:
             return parts[0].strip()
 
-    if " aka " in value:
-        parts = value.split(" aka ")
+    if " aka " in lower:
+        parts = lower.split(" aka ")
         if len(parts) == 2:
             return parts[0].strip()
     return value

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -403,7 +403,8 @@ TRANSFORMERS = {
 def _normalize_multivalue_delimiters(value: str, delimiter: str) -> str:
     """Normalize the delimiters in the provided value to the provided delimiter."""
     new_value = re.sub(FM_DELIMITER_PATTERN, delimiter, value)
-    logger.debug(f"Normalized delimiters: {value!r} -> {new_value!r}")
+    if new_value != value:
+        logger.debug(f"Normalized delimiters: {value!r} -> {new_value!r}")
     return new_value
 
 
@@ -503,6 +504,7 @@ def _initialize_client(config: dict) -> FilemakerClient:
         client = FilemakerClient(
             user=config["filemaker"]["user"],
             password=config["filemaker"]["password"],
+            timeout=240,
         )
         logger.info("Connected to Filemaker.")
         return client

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -441,6 +441,11 @@ def _split_multivalue_field(
 
     # Handle special cases
     if field_name == "Language":
+        if "N/A" in value:
+            logger.debug(
+                "Found known value 'N/A' in language field; replacing with 'NONE'."
+            )
+            value = value.replace("N/A", "NONE")
         # Normalize FM delimiters to comma for language
         value = _normalize_multivalue_delimiters(value, delimiter)
     elif field_name == "director":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Install `ftva-etl` package
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.3.0
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.3.1
 xmltodict==0.14.2
 # For Excel conversion
 pandas==2.2.3

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -132,6 +132,10 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
                 "Jane Doe, William Goodrich i.e. , Roscoe Arbuckle",
                 "Jane Doe, William Goodrich",
             ),  # i.e. with space before comma does not split multivalue on that comma
+            (
+                "David MacDonald, Mervyn LeRoy, John O'Brien Doe, LeeRoy Jenkins",
+                "David MacDonald, Mervyn LeRoy, John O'Brien Doe, LeeRoy Jenkins",
+            ),  # special case: return names with internal capitalization as-is
         ]
 
     def test_production_type_mapping(self):

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -157,6 +157,22 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
                 "Wally Bulloch",
             ),  # bad leading delimiter should not yield empty values
             (
+                "John Smith, Tom Jones,",
+                "John Smith, Tom Jones",
+            ),  # trailing comma should get stripped
+            (
+                "John Smith,, Tom Jones",
+                "John Smith, Tom Jones",
+            ),  # bad delimiters in middle of value should not yield empty values
+            (
+                "John Smith,Tom Jones",
+                "John Smith, Tom Jones",
+            ),  # delimiter missing space should get replaced with delimiter + space
+            (
+                "John Smith, Tom Jones \r\r",
+                "John Smith, Tom Jones",
+            ),  # trailing carriage returns should get stripped
+            (
                 "Mashuq M Deen, Dawn D Deason",
                 "Mashuq M. Deen, Dawn D. Deason",
             ),  # single initials should get trailing dot

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -68,6 +68,71 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
                 "No linguistic content, English",
             ),  # "N/A" should be processed as "No linguistic content" and not split
         ]
+        self.test_director_values = [
+            (
+                "OLEG LITVAK, william heick, R.J. CUTLER, MARY ANN DOANE, john a.b.c. doe",
+                "Oleg Litvak, William Heick, R.J. Cutler, Mary Ann Doane, John A.B.C. Doe",
+            ),  # capitalization variations
+            (
+                "Diego de la Texera, JOHN VAN DER DOE",
+                "Diego de la Texera, John van der Doe",
+            ),  # particles kept lowercase
+            (
+                "Richard Ray Perez and Lorena Parlee",
+                "Richard Ray Perez, Lorena Parlee",
+            ),  # "and" delimiter
+            (
+                "Debra Chasnoff\rKim Klausner\rMargaret Lazarus",
+                "Debra Chasnoff, Kim Klausner, Margaret Lazarus",
+            ),  # \r delimiter
+            (
+                "Ray Taylor & Lewis D. Collins",
+                "Ray Taylor, Lewis D. Collins",
+            ),  # ampersand delimiter
+            (
+                "Ford Beebe ; John Rawlins",
+                "Ford Beebe, John Rawlins",
+            ),  # semicolon delimiter
+            (
+                "Monogram Productions, Inc. ; a King Brothers production",
+                "Monogram Productions, Inc. ; a King Brothers production",
+            ),  # multiple delimiters--keep as-is
+            ("n/a", "N/A"),  # special case, null value
+            ("N/A", "N/A"),  # special case, null value
+            ("N/a", "N/A"),  # special case, null value
+            ("No Director listed", "N/A"),  # special case, null value
+            ("null, NULL", "Unknown"),  # special case, null value
+            ("unknown, UNKNOWN, Unknown", "Unknown"),  # special case, null value
+            ("   ", "Unknown"),  # special case, empty value
+            (
+                "john director-doe",
+                "John Director-Doe",
+            ),  # special case, hyphenated surname
+            (
+                "Lew Landers (as Louis Friedlander)",
+                "Louis Friedlander",
+            ),  # credited name after parenthetical "as"
+            (
+                "JANE DIRECTOR AS STAGE NAME",
+                "Stage Name",
+            ),  # "as" delimiter, case-insensitive
+            (
+                "William Goodrich [i.e. Roscoe Arbuckle]",
+                "William Goodrich",
+            ),  # take name before bracketed i.e.
+            (
+                "Marcus aka Sid Marcus",
+                "Marcus",
+            ),  # take name before aka
+            (
+                "John Doe (aka John D)",
+                "John Doe",
+            ),  # take name before parenthetical aka
+            (
+                "Jane Doe, William Goodrich i.e. , Roscoe Arbuckle",
+                "Jane Doe, William Goodrich",
+            ),  # i.e. with space before comma does not split multivalue on that comma
+        ]
 
     def test_production_type_mapping(self):
         for input, expected in self.test_production_type_values:
@@ -79,4 +144,10 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
         for input, expected in self.test_language_values:
             with self.subTest(input=input, expected=expected):
                 new_value = _apply_transformers("Language", input)
+                self.assertEqual(new_value, expected)
+
+    def test_director_mapping(self):
+        for input, expected in self.test_director_values:
+            with self.subTest(input=input, expected=expected):
+                new_value = _apply_transformers("director", input)
                 self.assertEqual(new_value, expected)

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -74,9 +74,9 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
                 "Oleg Litvak, William Heick, R.J. Cutler, Mary Ann Doane, John A.B.C. Doe",
             ),  # capitalization variations
             (
-                "Diego de la Texera, JOHN VAN DER DOE",
-                "Diego de la Texera, John van der Doe",
-            ),  # particles kept lowercase
+                "Diego de la Texera, John Van Der Doe",
+                "Diego de la Texera, John Van Der Doe",
+            ),  # Mixed-case remains as-is
             (
                 "Richard Ray Perez and Lorena Parlee",
                 "Richard Ray Perez, Lorena Parlee",
@@ -97,17 +97,17 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
                 "Monogram Productions, Inc. ; a King Brothers production",
                 "Monogram Productions, Inc. ; a King Brothers production",
             ),  # multiple delimiters--keep as-is
-            ("n/a", "N/A"),  # special case, null value
-            ("N/A", "N/A"),  # special case, null value
-            ("N/a", "N/A"),  # special case, null value
-            ("No Director listed", "N/A"),  # special case, null value
-            ("null, NULL", "Unknown"),  # special case, null value
-            ("unknown, UNKNOWN, Unknown", "Unknown"),  # special case, null value
-            ("   ", "Unknown"),  # special case, empty value
+            ("n/a", "N/A"),  # testing null value mapping
+            ("N/A", "N/A"),  # testing null value mapping
+            ("N/a", "N/A"),  # testing null value mapping
+            ("No Director listed", "N/A"),  # testing null value mapping
+            ("null, NULL", "Unknown"),  # testing null value mapping
+            ("unknown, UNKNOWN, Unknown", "Unknown"),  # testing null value mapping
+            ("   ", "Unknown"),  # empty value
             (
                 "john director-doe",
                 "John Director-Doe",
-            ),  # special case, hyphenated surname
+            ),  # hyphenated surname
             (
                 "Lew Landers (as Louis Friedlander)",
                 "Louis Friedlander",
@@ -115,7 +115,7 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             (
                 "JANE DIRECTOR AS STAGE NAME",
                 "Stage Name",
-            ),  # "as" delimiter, case-insensitive
+            ),  # credited name after parenthetical "as"
             (
                 "William Goodrich [i.e. Roscoe Arbuckle]",
                 "William Goodrich",
@@ -131,11 +131,27 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             (
                 "Jane Doe, William Goodrich i.e. , Roscoe Arbuckle",
                 "Jane Doe, William Goodrich",
-            ),  # i.e. with space before comma does not split multivalue on that comma
+            ),  # `i.e.` with space before comma should not split multivalue on that comma
             (
                 "David MacDonald, Mervyn LeRoy, John O'Brien Doe, LeeRoy Jenkins",
                 "David MacDonald, Mervyn LeRoy, John O'Brien Doe, LeeRoy Jenkins",
-            ),  # special case: return names with internal capitalization as-is
+            ),  # return names with internal capitalization as-is
+            (
+                "Ub Iwerks (uncredited)Shamus Culhane(co-director)",
+                "Ub Iwerks (uncredited), Shamus Culhane(co-director)",
+            ),  # insert `, ` between right parenthesis and uppercase letter
+            (
+                "1.Brad Bird\r2. Sam Raimi\r3.Jared Hess\r4. Adam Mckay",
+                "1. Brad Bird, 2. Sam Raimi, 3. Jared Hess, 4. Adam Mckay",
+            ),  # capitalize numbered names
+            (
+                "Richard Gerdau ;",
+                "Richard Gerdau",
+            ),  # bad trailing delimiter should not yield empty values
+            (
+                ", Wally Bulloch",
+                "Wally Bulloch",
+            ),  # bad leading delimiter should not yield empty values
         ]
 
     def test_production_type_mapping(self):

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -115,7 +115,7 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             (
                 "JANE DIRECTOR AS STAGE NAME",
                 "Stage Name",
-            ),  # credited name after parenthetical "as"
+            ),  # credited name after case-insensitive "as"
             (
                 "William Goodrich [i.e. Roscoe Arbuckle]",
                 "William Goodrich",
@@ -132,6 +132,10 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
                 "Jane Doe, William Goodrich i.e. , Roscoe Arbuckle",
                 "Jane Doe, William Goodrich",
             ),  # `i.e.` with space before comma should not split multivalue on that comma
+            (
+                "André De Toth (as Andre deToth)",
+                "Andre deToth",
+            ),  # name following "as" keeps casing
             (
                 "David MacDonald, Mervyn LeRoy, John O'Brien Doe, LeeRoy Jenkins",
                 "David MacDonald, Mervyn LeRoy, John O'Brien Doe, LeeRoy Jenkins",
@@ -152,6 +156,14 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
                 ", Wally Bulloch",
                 "Wally Bulloch",
             ),  # bad leading delimiter should not yield empty values
+            (
+                "Mashuq M Deen, Dawn D Deason",
+                "Mashuq M. Deen, Dawn D. Deason",
+            ),  # single initials should get trailing dot
+            (
+                "Alex Alferov c/o All Media",
+                "Alex Alferov c/o All Media",
+            ),  # special token "c/o" should be lowercase
         ]
 
     def test_production_type_mapping(self):

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -180,6 +180,10 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
                 "Alex Alferov c/o All Media",
                 "Alex Alferov c/o All Media",
             ),  # special token "c/o" should be lowercase
+            (
+                "1.JOHN A.B.C. DOE; jane doe (credited as jane star); LeeRoy Jenkins",
+                "1. John A.B.C. Doe, Jane Star, LeeRoy Jenkins",
+            ),  # composite test: multiple transformations
         ]
 
     def test_production_type_mapping(self):


### PR DESCRIPTION
Implements [DLSR-245](https://uclalibrary.atlassian.net/browse/DLSR-245)

### Acceptance criteria
- [X] Extend `filemaker_batch_update.py` to apply the cleanup rules for director, as per [these specs](https://uclalibrary.atlassian.net/wiki/x/BwBRZw)
- [X] The script should allow users to specify which field is being cleaned up

### Description
This PR adds functionality for batch updating the `director` field in Filemaker. Per the specs linked above, the script should first handle delimiters in the FM values, returning the value as-is if it contains more than one type of delimiter (e.g. both comma and semi-colon). This logic is handled (maybe a little awkwardly) in `_split_multivalue_field`. After that, the transformers apply on the individual split values from FM, before being rejoined with `, `:
- `_trim_whitespace`: straightforward trimming
- `_parse_credited_names`: this handles the "5. Pseudonyms and Credited Names" section of the specs
- `_standardize_director_name`: <del>this handles initials and particles in the middle of names (e.g. `de la` and `van der`). For transparency, I used a Cursor Agent pretty liberally for help with this function and its helpers. I liked its more robust and flexible solution, especially for keeping initials capitalized, better than my initial attempts. It also came up with a nice list of `DIRECTOR_NAME_PARTICLES`.</del> **Update**: this now applies a sequence of evaluations and string substitutions mainly using regular expressions, to cover the capitalization rules, handle quoted nicknames, roman numerals, lowercasing `c/o`, and handling numbered names. It's more fully commented than it was previously, and I think it reads more clearly that the previous iteration.
- Then finally known mappings are applied to handle "4. Indeterminate and null values"

I adjusted the `timeout` param on the `FilemakerClient` to 240 from 120, because I was running into timeouts again.

I also bumped the version of `ftva-etl` to `v0.3.1` so the new FM layout is targeted.

#### Refactors to `_split_multivalue_field()`
I refactored `_split_multivalue_field()` to apply different splitting rules on a per-field basis, rather than per delimiter enum. This function is probably a good candidate for a more general refactor to make it more modular and generic, but for the time being, I created a conditional branch for `director`, which requires particular logic for splitting up most multi-value inputs, while leaving some untouched.

Rules 1, 3, and 9 from the standardization rules are handled here, rather than in the functions listed in `TRANSFORMERS`.

### Testing
I added tests to cover the various examples included in the specs, plus some others I came up with. Brings the total to 34 tests.

My `dry_run` of the script took longer than the other fields so far--nearly 2 hours: 

`python filemaker_batch_update.py -c config_dev.toml -f director --dry_run`

Here's my output summary:

`Processing complete. Processed 598686 Filemaker record(s). Would update 448208 record(s) with 448208 total field change(s).`

The large number of records updated is attributable to mapping empty strings `''` to `Unknown`.

#### Update
My latest `dry_run` took a little less than an hour. Here's the summary:

`Processing complete. Processed 598699 Filemaker record(s). Would update 445914 record(s) with 445914 total field change(s).`

The discrepancy in update counts almost certainly has to do with rule changes, as there are more values being left untouched now, though not that many relatively speaking.

I also fixed the issue with the print statement for the final iteration in the logs, so now it reads `Pagination complete. All records retrieved.` after the last page is fetched from FM.

[DLSR-245]: https://uclalibrary.atlassian.net/browse/DLSR-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ