### PR TITLE
DLSR-277: Add shim to handle inventory number inconsistencies

### DIFF
--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -177,10 +177,33 @@ def _process_input_data(
             if bib_records:
                 bib_record = bib_records[0]
             else:
-                logger.info(
-                    f"No Alma bib records found for inventory number '{inventory_number}' "
-                    f"on record {row['dl_record_id']}. Proceeding with DD and FM data only."
-                )
+                # If no Alma bib record is found, retry with suffixes "T", "M", and "R".
+                # NOTE: This is a shim to deal with inconsistencies with inv numbers across systems.
+                for suffix in ["T", "M", "R"]:
+                    logger.info(
+                        f"No Alma bib records found for inventory number '{inventory_number}' "
+                        f"on record {row['dl_record_id']}. Retrying with suffix '{suffix}'."
+                    )
+                    all_bib_records = alma_sru_client.search_by_call_number(
+                        inventory_number + suffix
+                    )
+                    bib_records = filter_by_inventory_number_and_library(
+                        all_bib_records, inventory_number + suffix
+                    )
+                    if bib_records:
+                        logger.info(
+                            "Found Alma bib record for "
+                            f"inventory number '{inventory_number + suffix}' "
+                            f"(note suffix '{suffix}') on record {row['dl_record_id']}. "
+                            "Proceeding with DD, FM, and Alma data."
+                        )
+                        bib_record = bib_records[0]
+                        break
+                if not bib_record:
+                    logger.warning(
+                        f"No Alma bib records found for inventory number '{inventory_number}' "
+                        f"on record {row['dl_record_id']}. Proceeding with DD and FM data only."
+                    )
             filemaker_record = filemaker_client.search_by_inventory_number(
                 inventory_number
             )[0]

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -14,6 +14,7 @@ from ftva_etl import (
 from ftva_etl.metadata.utils import filter_by_inventory_number_and_library
 from requests.exceptions import HTTPError
 from warnings import deprecated
+from pymarc import Record
 
 
 # Module-level logger used throughout this module.
@@ -139,6 +140,42 @@ def _initialize_clients(
     )
 
 
+def _get_alma_bib_record(
+    inv_no_stem: str,
+    alma_sru_client: AlmaSRUClient,
+) -> Record | None:
+    """Get the Alma bib record for the provided inventory number,
+    retrying with suffixes "T", "M", and "R" if no record is found without suffix.
+
+    :param inv_no_stem: The base inventory number to search for.
+    :param alma_sru_client: The AlmaSRUClient instance to use to get the bib record.
+    :return: Matching Alma bib record, or None if no record is found.
+    """
+    # Try no suffix first, then "T", "M", and "R".
+    # NOTE: The additional suffixes are a shim
+    # to deal with inconsistent inventory numbers across systems.
+    suffixes = ["", "T", "M", "R"]
+    inv_nos_to_check = [inv_no_stem + suffix for suffix in suffixes]
+    # There may not be any matches - if so, this is a "1-to-1" record,
+    # so we'll use only DD and FM data.
+    bib_record = None
+    for inv_no in inv_nos_to_check:
+        search_results = alma_sru_client.search_by_call_number(inv_no)
+        filtered_bib_records: list[Record] = filter_by_inventory_number_and_library(
+            search_results, inv_no
+        )
+        if filtered_bib_records:
+            # Take the first record that matches the inventory number and is from FTVA
+            bib_record = filtered_bib_records[0]
+            if inv_no != inv_no_stem:
+                logger.info(
+                    f"Inventory number '{inv_no_stem}' from DD "
+                    f"matched to '{inv_no}' in Alma."
+                )
+            break
+    return bib_record
+
+
 def _process_input_data(
     input_data: list[dict],
     alma_sru_client: AlmaSRUClient,
@@ -163,47 +200,15 @@ def _process_input_data(
                 row["dl_record_id"]
             )
             inventory_number = digital_data_record["inventory_number"]
-            # First get all results from Alma matching the inventory number
-            # There may not be any matches - if so, this is a "1-to-1" record,
-            # so we'll use only DD and FM data.
-            # Initialize bib_record variable first so we can check for it later.
-            bib_record = None
-            all_bib_records = alma_sru_client.search_by_call_number(inventory_number)
-            # Take the first record that matches the inventory number and is from FTVA library.
-            # This prevents false matches from other libraries.
-            bib_records = filter_by_inventory_number_and_library(
-                all_bib_records, inventory_number
-            )
-            if bib_records:
-                bib_record = bib_records[0]
-            else:
-                # If no Alma bib record is found, retry with suffixes "T", "M", and "R".
-                # NOTE: This is a shim to deal with inconsistencies with inv numbers across systems.
-                for suffix in ["T", "M", "R"]:
-                    logger.info(
-                        f"No Alma bib records found for inventory number '{inventory_number}' "
-                        f"on record {row['dl_record_id']}. Retrying with suffix '{suffix}'."
-                    )
-                    all_bib_records = alma_sru_client.search_by_call_number(
-                        inventory_number + suffix
-                    )
-                    bib_records = filter_by_inventory_number_and_library(
-                        all_bib_records, inventory_number + suffix
-                    )
-                    if bib_records:
-                        logger.info(
-                            "Found Alma bib record for "
-                            f"inventory number '{inventory_number + suffix}' "
-                            f"(note suffix '{suffix}') on record {row['dl_record_id']}. "
-                            "Proceeding with DD, FM, and Alma data."
-                        )
-                        bib_record = bib_records[0]
-                        break
-                if not bib_record:
-                    logger.warning(
-                        f"No Alma bib records found for inventory number '{inventory_number}' "
-                        f"on record {row['dl_record_id']}. Proceeding with DD and FM data only."
-                    )
+
+            bib_record = _get_alma_bib_record(inventory_number, alma_sru_client)
+            if not bib_record:
+                logger.warning(
+                    f"No Alma bib record found for inventory number '{inventory_number}' "
+                    f"on record {row['dl_record_id']}. Proceeding with DD and FM data only."
+                )
+                continue
+
             filemaker_record = filemaker_client.search_by_inventory_number(
                 inventory_number
             )[0]


### PR DESCRIPTION
Implements [DLSR-277](https://uclalibrary.atlassian.net/browse/DLSR-277)

### Acceptance criteria
- [X] `generate_metadata.py` is updated to handle known inventory number inconsistencies between DD and Alma

### Description
Adds a shim to retry the Alma search with three known suffixes `T`, `M`, and `R` for DD inventory numbers that don't match any Alma call numbers. For example, if `VA15789` does not result in a matched Alma record, it will be retried as `VA15789T` and so on.

### Testing
This shim allowed [Batch 1](https://docs.google.com/spreadsheets/d/1LAbSnTm7YCvkJRrerJKReAvWKyrGKQYNkH-ZecN4FvM/edit?usp=sharing) to be regenerated with all records matching Alma items.

[DLSR-277]: https://uclalibrary.atlassian.net/browse/DLSR-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ