### PR TITLE
DLSR-244: fix bug with 'N/A' language value

### DIFF
--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -277,9 +277,14 @@ def _split_multivalue_field(value: str, delimiter: str) -> list[str]:
     """Split a multi-value field into a list of values, based on the provided delimiter.
     Also trims whitespace from each value and filters out any empty values."""
     if delimiter == FieldDelimiters["Language"].value:
-        # First, check for the known value "N/A", which should not be split
-        if value.strip() == "N/A":
-            return [value.strip()]
+        # First, check for the known value "N/A.
+        # If present, replace with "NONE" and process as usual,
+        # which will eventually be mapped to "No linguistic content" by the mapping function.
+        if "N/A" in value:
+            logger.debug(
+                "Found known value 'N/A' in language field; replacing with 'NONE'."
+            )
+            value = value.replace("N/A", "NONE")
         # Normalize all possible delimiters to comma for language
         value = re.sub(r"\s*(?:[,;/|]|\band\b|&|\r)\s*", ", ", value)
         logger.debug(f"Normalized delimiters to comma: {value!r}")

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -277,6 +277,9 @@ def _split_multivalue_field(value: str, delimiter: str) -> list[str]:
     """Split a multi-value field into a list of values, based on the provided delimiter.
     Also trims whitespace from each value and filters out any empty values."""
     if delimiter == FieldDelimiters["Language"].value:
+        # First, check for the known value "N/A", which should not be split
+        if value.strip() == "N/A":
+            return [value.strip()]
         # Normalize all possible delimiters to comma for language
         value = re.sub(r"\s*(?:[,;/|]|\band\b|&|\r)\s*", ", ", value)
         logger.debug(f"Normalized delimiters to comma: {value!r}")

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -62,6 +62,7 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             ("Portuguese for Brazil", "Portuguese"),  # special case, known value
             ("?", "Undetermined"),  # special case, known value
             ("Russian Intertitles", "Russian"),  # "Intertitles" should be removed
+            ("N/A", "No linguistic content"),  # special case, known value
         ]
 
     def test_production_type_mapping(self):

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -63,6 +63,10 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             ("?", "Undetermined"),  # special case, known value
             ("Russian Intertitles", "Russian"),  # "Intertitles" should be removed
             ("N/A", "No linguistic content"),  # special case, known value
+            (
+                "N/A | English",
+                "No linguistic content, English",
+            ),  # "N/A" should be processed as "No linguistic content" and not split
         ]
 
     def test_production_type_mapping(self):


### PR DESCRIPTION
Fixes [DLSR-244](https://uclalibrary.atlassian.net/browse/DLSR-244)

A small change and corresponding test to correctly map the Language value “N/A” to “No linguistic content”.

Currently, the first processing step of the script is to attempt to split the multivalue Language field into individual components. This includes splitting on slashes (for cases like "English/French"), which caused the value "N/A" to split into "N, A". 

To address this, I added a case in `_split_multivalue_field()` to return the value "N/A" as is, which allows the script to correctly map it in a later step.  This seemed like the most straightforward approach, but it would not work correctly for a Language value like "English, N/A". For now, I can confirm that there are/were no instances of N/A combined with another value in the FM database.

I added one test, for a total of 33: `docker compose exec ftva_data python -m unittest`

[DLSR-244]: https://uclalibrary.atlassian.net/browse/DLSR-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ