### PR TITLE
DLSR-245: Add `retry` library to `requirements.txt`

### DIFF
--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -9,8 +9,9 @@ from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
 from ftva_etl import FilemakerClient
-from fmrest.exceptions import FileMakerError
+from fmrest.exceptions import FileMakerError, RequestException
 from fmrest.record import Record
+from retry.api import retry_call
 
 # Creating module-level logger here;
 # handlers are configured via `_configure_logging`.
@@ -621,11 +622,21 @@ def _process_record(
 
     if pending_changes and not dry_run:
         try:
-            success = fm_client.edit_record(
-                record_id=record_id, field_data=pending_changes
+            # Retry up to 10 times with long backoff between attempts,
+            # in order to handle non-`FileMakerError` exceptions such as `RequestException`,
+            # likely originating from rate limiting or other issues on the Filemaker server.
+            success = retry_call(
+                fm_client.edit_record,
+                fargs=[record_id, pending_changes],
+                exceptions=(RequestException,),
+                tries=10,
+                delay=1,
+                backoff=4,
+                max_delay=60,
+                logger=logger,
             )
+        # For `FileMakerError` exceptions, log the error and continue processing other records
         except FileMakerError as e:
-            # Log the error and continue processing other records
             logger.error(
                 f"Skipping record_id={record_id} inventory_id={inventory_id!r} "
                 f"due to Filemaker error: {e}. "

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ openpyxl==3.1.5
 strsimpy==0.2.1
 # Alma API and analytics client 
 git+https://github.com/UCLALibrary/alma-api-client
+# For retrying requests to Filemaker API
+retry==0.9.2


### PR DESCRIPTION
Improves [DLSR-245](https://uclalibrary.atlassian.net/browse/DLSR-245)

### Description
Running the batch update against the `director` field resulted in `fmrest.exceptions.RequestException` on several runs of the program, likely due to rate limits or other issues on the Filemaker server. This PR adds the `retry` library and uses its `retry_call` function to retry the call to `fm_client.edit_record`, with exponential back-off on `RequestException`.

I went ahead and restarted the program with these changes, and the retries seem to be working well, so far resolving all `RequestException` cases within 1 try. Server-side tuning might be more appropriate for future high-volume batch updates like this one, where nearly every record is updated, but for now this looks like it works.

[DLSR-245]: https://uclalibrary.atlassian.net/browse/DLSR-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ