### PR TITLE
DLSR-246: FM batch updates for dates

### DIFF
--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -170,8 +170,8 @@ class FieldDelimiters(StrEnum):
     production_type = "\r"
     Language = ", "
     director = ", "
-    release_broadcast_date = "\r"
-    record_date = "\r"
+    release_broadcast_year = "; "
+    record_date = "; "
 
 
 def _trim_whitespace(value: str) -> str:
@@ -410,16 +410,16 @@ def _normalize_copyright_and_circa(value: str) -> str:
     copyright_pattern = re.compile(r"c(?:opyright)?\.?\s*(\d{4})", re.IGNORECASE)
     value = copyright_pattern.sub(r"c\1", value)
 
-    # Circa: Replace circa, ca., CA., CIRCA, c. with year?
-    # ca. 1919 -> 1919?; CIRCA 1970 -> 1970?
-    # c. 1910 -> 1910?
+    # Circa: Replace circa, ca., CA., CIRCA, c. with question mark after year
+    # Exception: Convert circa date range to “or” format first
+    # circa 1929-1930 -> 1929 or 1930
+    value = re.sub(r"(?i)circa\s+(\d{4})\s*[-–]\s*(\d{4})", r"\1 or \2", value)
+
+    # Circa: Replace single-year circa variations with question mark after year
+    # e.g. circa 1970 -> 1970?
     value = re.sub(
         r"(?i)\b(?:circa|ca\.?|c\.)\s*(\d{4})\b", lambda m: f"{m.group(1)}?", value
     )
-
-    # Exception: Convert circa date range to “or” format
-    # circa 1929-1930 -> 1929 or 1930
-    value = re.sub(r"(?i)circa\s+(\d{4})\s*[-–]\s*(\d{4})", r"\1 or \2", value)
     return value.strip()
 
 
@@ -627,7 +627,7 @@ TRANSFORMERS = {
         _handle_U_X_placeholders,
         _normalize_date_ranges,
     ],
-    "release_broadcast_date": [
+    "release_broadcast_year": [
         _trim_whitespace,
         lambda value: MAPPINGS["date"].get(value, value),
         _remove_brackets,
@@ -765,6 +765,9 @@ def _initialize_client(config: dict) -> FilemakerClient:
             timeout=240,
         )
         logger.info("Connected to Filemaker.")
+        print(
+            client._fms
+        )  # Log the internal FilemakerServer instance for debugging connection issues
         return client
     except FileMakerError as e:
         logger.error(f"Failed to connect to Filemaker: {e}")
@@ -840,7 +843,7 @@ def _process_record(
         if current_value == new_value:  # skip if no change
             continue
 
-        logger.debug(
+        logger.info(
             f"UPDATE field_name={field_name} "
             f"record_id={record_id} inventory_id={inventory_id} "
             f"from={current_value!r} to={(new_value or '')!r}"  # use `!r` so `\r` is visible in log
@@ -931,6 +934,7 @@ def main() -> None:
     args = _get_arguments()
     _configure_logging(dry_run=args.dry_run)
     config = _get_config(args.config_file)
+    logger.info(config)
 
     if args.dry_run:
         logger.info("DRY RUN: no changes will be written to Filemaker.")

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -413,18 +413,43 @@ def _normalize_copyright_and_circa(value: str) -> str:
     """Normalize various representations of "Copyright" and "Circa" in the provided value."""
     # Copyright: Standardize to lowercase c followed immediately by year.
     # c 1978, C1988, COPYRIGHT 2007 -> c1978, c1988, c2007
-    value = re.sub(r"(?i)c(?:opyright)?\.?\s*(\d{4})", r"c\1", value)
+    # Normalize curly apostrophes to simple ASCII
+    value = value.replace("’", "'").replace("‘", "'")
+
+    # Normalize decade forms with apostrophes (e.g. "1920's", "1920’s") to a consistent
+    # representation so subsequent rules can detect decades reliably.
+    value = re.sub(
+        r"(\d{3})0['’]s\??", lambda m: f"{m.group(1)}-?", value, flags=re.IGNORECASE
+    )
+
+    # If a circa/token prefix remains (e.g. "ca. 192-?"), drop the prefix so we
+    # end up with the normalized decade token ("192-?"). Only remove the prefix
+    # when what follows looks like a normalized decade (three digits + '-?').
+    value = re.sub(r"(?i)^(?:circa|ca\.?|c\.? )\s*(?=\d{3}-\?)", "", value)
+
+    # COPYRIGHT: Standardize to lowercase c followed immediately by year.
+    # Require a word-boundary after the year so we don't accidentally match decade tokens
+    # such as "1970s" (which should be handled above).
+    value = re.sub(r"(?i)c(?:opyright)?\.?\s*(\d{4})\b\.?", r"c\1", value)
 
     # Circa: Replace circa, ca., CA., CIRCA, c. with question mark after year
     # Exception: Convert circa date range to “or” format first
     # circa 1929-1930 -> 1929 or 1930
     value = re.sub(r"(?i)circa\s+(\d{4})\s*[-–]\s*(\d{4})", r"\1 or \2", value)
 
+    # Handle circa + decade (e.g. "c. 1970s", "ca. 1920's") -> normalize to decade uncertainty
+    value = re.sub(
+        r"(?i)(?:circa|ca\.?|c\.)\s*(\d{3})0s\b\??", lambda m: f"{m.group(1)}-?", value
+    )
+
     # Circa: Replace single-year circa variations with question mark after year
     # e.g. circa 1970 -> 1970?
     value = re.sub(
         r"(?i)\b(?:circa|ca\.?|c\.)\s*(\d{4})\b", lambda m: f"{m.group(1)}?", value
     )
+
+    # If 'circa' follows the year (e.g. '1924 circa') normalize to '1924?'
+    value = re.sub(r"(?i)(\d{4})\s*(?:circa|ca\.?|c\.?)\b", r"\1?", value)
     return value.strip()
 
 
@@ -435,7 +460,8 @@ def _normalize_date(value: str) -> str:
     value = (value or "").strip()
     # If value contains multiple full numeric dates separated by commas, leave as-is
     # e.g. "11-12-1959, 11-19-1959" or "04/02/1959, 04/09/1959"
-    if "," in value:
+    # If multiple full numeric dates appear separated by commas or newlines, leave as-is
+    if "," in value or "\r" in value or "\n" in value:
         multi_dates = re.findall(r"\b\d{1,2}[/-]\d{1,2}[/-]\d{4}\b", value)
         if len(multi_dates) > 1:
             return value
@@ -461,8 +487,11 @@ def _normalize_date(value: str) -> str:
         "Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec"
     )
     # Match month followed by a day-day range, optionally with a year suffix.
+    # Include ampersand and the word 'and' as range separators (e.g. "October 17 & 18, 1989").
     day_range_regex = (
-        rf"^({month_names})\b\s+\d{{1,2}}\s*[-–]\s*\d{{1,2}}(?:\s*,\s*\d{{4}})?$"
+        rf"^({month_names})\b"
+        r"\s+\d{1,2}\s*(?:[-–]|&|\band\b)\s*"
+        r"\d{1,2}(?:\s*,\s*\d{4})?$"
     )
     if re.match(day_range_regex, value, re.IGNORECASE):
         return value
@@ -581,6 +610,10 @@ def _normalize_date_ranges(value: str) -> str:
     )
     # Spaced dash: 1959 - 1963 -> 1959-1963
     value = re.sub(r"(\d{4})\s*-\s*(\d{4})", r"\1-\2", value)
+    # Range where second part is a decade (e.g. 1960-1970s) -> normalize to 1960-1970
+    value = re.sub(
+        r"(\d{4})-(\d{3})0s\b", lambda m: f"{m.group(1)}-{m.group(2)}0", value
+    )
     # Two-digit second year: Assume same century as first year: 1975-76 -> 1975-1976
     # Only expand two-digit second years when they are unlikely to be months
     # (e.g., 76 -> 1976). If the second group looks like a month (01-12), leave it alone.

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -438,28 +438,34 @@ def _normalize_date(value: str) -> str:
     if not v or not re.search(r"\d", v):
         return v
 
-    # Apply partial-year and placeholder/range normalizers first so we don't
-    # accidentally let a short numeric string be parsed as a day/month.
-    # Note: run partial-year handling before replacing U/X so we can distinguish
-    # explicit trailing hyphens from ones created by placeholder replacement.
-    v = _handle_partial_years(v)
-    v = _handle_U_X_placeholders(v)
-    v = _normalize_date_ranges(v)
+    # Preserve copyright-like values such as 'c1978' (should not be parsed into a date)
+    if re.fullmatch(r"c\d{4}\??", v, flags=re.IGNORECASE):
+        return v
+
+    # If we already have a normalized YYYY-MM or YYYY-MM-DD or range, return it
+    if re.fullmatch(r"\d{4}-\d{2}(-\d{2})?", v) or re.fullmatch(r"\d{4}-\d{4}", v):
+        return v
 
     # If the value begins with a month name, prefer `dateparser` to produce
     # YYYY-MM or YYYY-MM-DD (avoid regex-heavy transformations here).
-    month_regex = (
-        r"^(January|February|March|April|May|June|July|August|September|October|November|December|"
-        r"Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\b"
+    # However, guard against month + day-range strings (e.g. "June 28-29",
+    # "May 9-10, 1980") which should be left unchanged.
+    month_names = (
+        "January|February|March|April|May|June|July|August|September|October|November|December|"
+        "Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec"
     )
+    # Match month followed by a day-day range, optionally with a year suffix.
+    day_range_regex = (
+        rf"^({month_names})\b\s+\d{{1,2}}\s*[-–]\s*\d{{1,2}}(?:\s*,\s*\d{{4}})?$"
+    )
+    if re.match(day_range_regex, v, re.IGNORECASE):
+        return v
+
+    month_regex = rf"^({month_names})\b"
     if re.match(month_regex, v, re.IGNORECASE):
         try:
-            # Use `PREFER_DAY_OF_MONTH: 'first'` so ambiguous month+year
-            # expressions (e.g. "Jan 1956") produce a stable canonical
-            # representation. We prefer YYYY-MM when a day is not present,
-            # but when a day is present we want a full YYYY-MM-DD. This
-            # setting ensures `dateparser` chooses the first day of the
-            # month rather than attempting to infer the day.
+            # Use `PREFER_DAY_OF_MONTH: 'first'` so dateparser always uses the
+            # first of the month rather than attempting to infer the day.
             dt = dateparser.parse(v, settings={"PREFER_DAY_OF_MONTH": "first"})
             if dt:
                 # If original contains an explicit day number, return full date
@@ -490,14 +496,6 @@ def _normalize_date(value: str) -> str:
         if 1 <= month <= 12:
             return f"{year:04d}-{month:02d}"
 
-    # Preserve copyright-like values such as 'c1978' (should not be parsed into a date)
-    if re.fullmatch(r"c\d{4}\??", v, flags=re.IGNORECASE):
-        return v
-
-    # If we already have a normalized YYYY-MM or YYYY-MM-DD or range, return it
-    if re.fullmatch(r"\d{4}-\d{2}(-\d{2})?", v) or re.fullmatch(r"\d{4}-\d{4}", v):
-        return v
-
     # Try EDTF parsing/validation next (handles u-placements, ? and ranges)
     v_edtf = re.sub(r"[UuXx]", "u", v)
     try:
@@ -513,7 +511,7 @@ def _normalize_date(value: str) -> str:
     try:
         # Only call dateparser when the transformed value looks like a
         # natural-language date (avoid interpreting short or placeholder
-        # strings as current-month dates). Use `v` (the transformed value).
+        # strings as current-month dates). Use v, the value after transformations.
         if re.search(r"[A-Za-z]|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}", v):
             # Make deterministic day selection (first) to avoid
             # unpredictable results when only month/year is present.
@@ -541,9 +539,6 @@ def _handle_partial_years(value: str) -> str:
     # Three digits: 195 -> 195-? (partial year)
     if re.match(r"^\d{3}$", value):
         return value + "-?"
-    # Three digits + dash: 195- -> 195-? (partial year)
-    if re.match(r"^\d{3}-$", value):
-        return value + "?"
     # Decades: 1950s -> 195-
     if re.match(r"^\d{3}0s$", value):
         return value[:3] + "-"
@@ -633,6 +628,9 @@ TRANSFORMERS = {
         lambda value: MAPPINGS["date"].get(value, value),
         _remove_brackets,
         _normalize_copyright_and_circa,
+        _handle_partial_years,
+        _handle_U_X_placeholders,
+        _normalize_date_ranges,
         _normalize_date,
     ],
     "release_broadcast_year": [
@@ -640,6 +638,9 @@ TRANSFORMERS = {
         lambda value: MAPPINGS["date"].get(value, value),
         _remove_brackets,
         _normalize_copyright_and_circa,
+        _handle_partial_years,
+        _handle_U_X_placeholders,
+        _normalize_date_ranges,
         _normalize_date,
     ],
 }
@@ -935,7 +936,6 @@ def main() -> None:
     args = _get_arguments()
     _configure_logging(dry_run=args.dry_run)
     config = _get_config(args.config_file)
-    logger.info(config)
 
     if args.dry_run:
         logger.info("DRY RUN: no changes will be written to Filemaker.")

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -148,13 +148,16 @@ MAPPINGS = {
     },
     "date": {
         "UUUU": "Unknown",
+        "uuuu": "Unknown",
         "UUUU-UUUU": "Unknown",
+        "uuuu-uuuu": "Unknown",
         "unknown": "Unknown",
         "UNKNOWN": "Unknown",
         "ND": "Unknown",
         "N": "Unknown",
         "nd": "Unknown",
         "no date": "Unknown",
+        "": "Unknown",
         "?": "Unknown",
         "n/a": "N/A",
     },
@@ -513,7 +516,15 @@ def _normalize_date(value: str) -> str:
 
     # Normalize common numeric date formats using `dateparser` where possible
     # MM/DD/YYYY or MM-DD-YYYY -> YYYY-MM-DD
-    if re.search(r"\b\d{1,2}[/-]\d{1,2}[/-]\d{4}\b", value):
+    m_full = re.search(r"\b(\d{1,2})[/-](\d{1,2})[/-](\d{4})\b", value)
+    if m_full:
+        month = int(m_full.group(1))
+        day = int(m_full.group(2))
+        year = int(m_full.group(3))
+        # Treat day '00' or '0' as unknown day: return YYYY-MM
+        if day == 0:
+            if 1 <= month <= 12:
+                return f"{year:04d}-{month:02d}"
         try:
             # For explicit numeric dates, set `PREFER_DAY_OF_MONTH` to keep
             # parsing deterministic (choose first-of-month when needed).
@@ -595,13 +606,26 @@ def _handle_U_X_placeholders(value: str) -> str:
     value = re.sub(r"(\d{2})[UuXx]{2}", r"\1--?", value)
     # Single U/u/X/x: 197u -> 197-
     value = re.sub(r"(\d{3})[UuXx]", r"\1-", value)
+    # Collapse ranges composed mostly of placeholders to more compact
+    # uncertain forms expected by tests.
+    # Full-year followed by placeholder-only range -> keep the known year
+    # (e.g. 1959-UUUU -> 1959)
+    m_full_right = re.match(r"^(\d{4})-[UuXx]+$", value)
+    if m_full_right:
+        return m_full_right.group(1)
+    # Three-digit left with placeholder-only right -> partial-year with ?
+    # (e.g. 193U-UUUU -> 193-?)
+    m_three_left = re.match(r"^(\d{3})-+[UuXx]+$", value)
+    if m_three_left:
+        return m_three_left.group(1) + "-?"
+    # If leftover sequences like '--UUUU' exist, collapse to '-?'
+    value = re.sub(r"-+[UuXx]+", "-?", value)
     return value
 
 
 def _normalize_date_ranges(value: str) -> str:
     """Normalize date ranges to a consistent format, if possible."""
-    # Slash range: 1955/1956 -> 1955-1956
-    value = re.sub(r"(\d{4})/(\d{4})", r"\1-\2", value)
+    # Preserve slash-delimited ranges (e.g. 1955/1956) — do not convert them to hyphens.
     # Bracket range: [1975-76] -> 1975-1976
     value = re.sub(
         r"\[(\d{4})-(\d{2})\]",

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -481,6 +481,30 @@ def _normalize_date(value: str) -> str:
     ):
         return value
 
+    # Handle two-digit year forms specially per Y2K-like rule: if the two-digit
+    # year is greater than the last two digits of the current year, interpret
+    # as 19YY; otherwise leave unchanged and log a warning for manual review.
+    m_two = re.search(r"\b(\d{1,2})[/-](\d{1,2})[/-](\d{2})\b", value)
+    if m_two:
+        month = int(m_two.group(1))
+        day = int(m_two.group(2))
+        yy = int(m_two.group(3))
+        cutoff = datetime.now().year % 100
+        if yy > cutoff:
+            year = 1900 + yy
+            if day == 0:
+                if 1 <= month <= 12:
+                    return f"{year:04d}-{month:02d}"
+            try:
+                return f"{year:04d}-{month:02d}-{day:02d}"
+            except (ValueError, TypeError, OverflowError):
+                return value
+        else:
+            logger.warning(
+                f"Two-digit year {yy:02d} in {value!r} <= cutoff {cutoff:02d}; left unchanged."
+            )
+            return value
+
     # If the value begins with a month name, prefer `dateparser` to produce
     # YYYY-MM or YYYY-MM-DD (avoid regex-heavy transformations here).
     # However, guard against month + day-range strings (e.g. "June 28-29",
@@ -606,8 +630,6 @@ def _handle_U_X_placeholders(value: str) -> str:
     value = re.sub(r"(\d{2})[UuXx]{2}", r"\1--?", value)
     # Single U/u/X/x: 197u -> 197-
     value = re.sub(r"(\d{3})[UuXx]", r"\1-", value)
-    # Collapse ranges composed mostly of placeholders to more compact
-    # uncertain forms expected by tests.
     # Full-year followed by placeholder-only range -> keep the known year
     # (e.g. 1959-UUUU -> 1959)
     m_full_right = re.match(r"^(\d{4})-[UuXx]+$", value)
@@ -625,7 +647,6 @@ def _handle_U_X_placeholders(value: str) -> str:
 
 def _normalize_date_ranges(value: str) -> str:
     """Normalize date ranges to a consistent format, if possible."""
-    # Preserve slash-delimited ranges (e.g. 1955/1956) — do not convert them to hyphens.
     # Bracket range: [1975-76] -> 1975-1976
     value = re.sub(
         r"\[(\d{4})-(\d{2})\]",
@@ -641,7 +662,6 @@ def _normalize_date_ranges(value: str) -> str:
     # Two-digit second year: Assume same century as first year: 1975-76 -> 1975-1976
     # Only expand two-digit second years when they are unlikely to be months
     # (e.g., 76 -> 1976). If the second group looks like a month (01-12), leave it alone.
-
     value = re.sub(r"(\d{4})-(\d{2})\b", _expand_two_digit_year, value)
     return value.strip()
 

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -144,6 +144,18 @@ MAPPINGS = {
         "N/A": "No linguistic content",
         "NONE": "No linguistic content",
     },
+    "date": {
+        "UUUU": "Unknown",
+        "UUUU-UUUU": "Unknown",
+        "unknown": "Unknown",
+        "UNKNOWN": "Unknown",
+        "ND": "Unknown",
+        "N": "Unknown",
+        "nd": "Unknown",
+        "no date": "Unknown",
+        "?": "Unknown",
+        "n/a": "N/A",
+    },
     "director": {
         "NO DIRECTOR LISTED": "N/A",
         "N/A": "N/A",
@@ -158,6 +170,8 @@ class FieldDelimiters(StrEnum):
     production_type = "\r"
     Language = ", "
     director = ", "
+    release_broadcast_date = "\r"
+    record_date = "\r"
 
 
 def _trim_whitespace(value: str) -> str:
@@ -384,6 +398,198 @@ def _normalize_language_spelling(value: str) -> str:
         return value
 
 
+def _remove_brackets(value: str) -> str:
+    """Remove square brackets and parentheses from the provided value, if present."""
+    return re.sub(r"[\[\]\(\)]", "", value).strip()
+
+
+def _normalize_copyright_and_circa(value: str) -> str:
+    """Normalize various representations of "Copyright" and "Circa" in the provided value."""
+    # Copyright: Standardize to lowercase c followed immediately by year.
+    # c 1978, C1988, COPYRIGHT 2007 -> c1978, c1988, c2007
+    copyright_pattern = re.compile(r"c(?:opyright)?\.?\s*(\d{4})", re.IGNORECASE)
+    value = copyright_pattern.sub(r"c\1", value)
+
+    # Circa: Replace circa, ca., CA., CIRCA, c. with year?
+    # ca. 1919 -> 1919?; CIRCA 1970 -> 1970?
+    # c. 1910 -> 1910?
+    value = re.sub(
+        r"(?i)\b(?:circa|ca\.?|c\.)\s*(\d{4})\b", lambda m: f"{m.group(1)}?", value
+    )
+
+    # Exception: Convert circa date range to “or” format
+    # circa 1929-1930 -> 1929 or 1930
+    value = re.sub(r"(?i)circa\s+(\d{4})\s*[-–]\s*(\d{4})", r"\1 or \2", value)
+    return value.strip()
+
+
+def _convert_natural_language_date(value: str) -> str:
+    """Convert natural language date expressions to a standardized format, if possible."""
+    # Only process if value starts with a month name (not a number)
+    month_regex = (
+        r"^(January|February|March|April|May|June|July|August|September|October|November|December|"
+        r"Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\b"
+    )
+    if not re.match(month_regex, value, re.IGNORECASE):
+        return value.strip()
+
+    month_map = {
+        "january": "01",
+        "jan": "01",
+        "february": "02",
+        "feb": "02",
+        "march": "03",
+        "mar": "03",
+        "april": "04",
+        "apr": "04",
+        "may": "05",
+        "june": "06",
+        "jun": "06",
+        "july": "07",
+        "jul": "07",
+        "august": "08",
+        "aug": "08",
+        "september": "09",
+        "sep": "09",
+        "sept": "09",
+        "october": "10",
+        "oct": "10",
+        "november": "11",
+        "nov": "11",
+        "december": "12",
+        "dec": "12",
+    }
+
+    def month_day_year_sub(m):
+        month_name = m.group(1).lower()
+        month = (
+            month_map[month_name]
+            if month_name in month_map
+            else month_map[month_name[:3]]
+        )
+        day = int(m.group(2))
+        year = m.group(3)
+        return f"{year}-{month}-{day:02d}"
+
+    value = re.sub(
+        r"\b(January|February|March|April|May|June|July|August|September|October|November|December|"
+        r"Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\s+(\d{1,2})\s*,?\s*(\d{4})\b",
+        month_day_year_sub,
+        value,
+        flags=re.IGNORECASE,
+    )
+
+    def month_year_sub(m):
+        month_name = m.group(1).lower()
+        month = (
+            month_map[month_name]
+            if month_name in month_map
+            else month_map[month_name[:3]]
+        )
+        year = m.group(2)
+        return f"{year}-{month}"
+
+    value = re.sub(
+        r"\b(January|February|March|April|May|June|July|August|September|October|November|December|"
+        r"Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\s+(\d{4})\b",
+        month_year_sub,
+        value,
+        flags=re.IGNORECASE,
+    )
+    return value.strip()
+
+
+def _normalize_date_format(value: str) -> str:
+    """Converts various date formats to a standardized YYYY-MM-DD or YYYY-MM format, if possible."""
+    # Strip whitespace before checking for normalized format
+    value_stripped = value.strip()
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", value_stripped) or re.fullmatch(
+        r"\d{4}-\d{2}", value_stripped
+    ):
+        return value_stripped
+
+    # MM/DD/YYYY or MM-DD-YYYY -> YYYY-MM-DD
+    value = re.sub(
+        r"\b(\d{1,2})[/-](\d{1,2})[/-](\d{4})\b",
+        lambda m: f"{m.group(3)}-{int(m.group(1)):02d}-{int(m.group(2)):02d}",
+        value,
+    )
+    # MM/YYYY or MM-YYYY -> YYYY-MM
+    value = re.sub(
+        r"\b(\d{1,2})[/-](\d{4})\b",
+        lambda m: f"{m.group(2)}-{int(m.group(1)):02d}",
+        value,
+    )
+    return value.strip()
+
+
+def _handle_partial_years(value: str) -> str:
+    """Normalize partial year formats to a consistent representation, if possible."""
+    # Two digits only: 19 -> 19--?
+    if value.isdigit() and len(value) == 2:
+        return value + "--?"
+    # Two digits + dash: 19- -> 19--
+    if re.match(r"^\d{2}-$", value):
+        return value[:2] + "--"
+    # Three digits: 195 -> 195-? (partial year)
+    if re.match(r"^\d{3}$", value):
+        return value + "-?"
+    # Three digits + dash: 195- -> 195-? (partial year)
+    if re.match(r"^\d{3}-$", value):
+        return value + "?"
+    # Decades: 1950s -> 195-
+    if re.match(r"^\d{3}0s$", value):
+        return value[:3] + "-"
+    # Two digits with ??: 19?? -> 19--?
+    if re.match(r"^\d{2}\?\?$", value):
+        return value[:2] + "--?"
+    return value
+
+
+def _handle_U_X_placeholders(value: str) -> str:
+    """Normalize U/X placeholders in dates to a consistent representation, if possible."""
+    # 19UU-UUUU or 19uu-uuuu or 19XX-XXXX -> 19--?
+    value = re.sub(r"(\d{2})[UuXx]{2}-[UuXx]{4}", r"\1--?", value)
+    # 19uu-1971 -> 19--?-1971
+    value = re.sub(r"(\d{2})[UuXx]{2}-(\d{4})", r"\1--?-\2", value)
+    # Double UU/uu/XX/xx: 19UU, 19uu, 19XX -> 19--?
+    value = re.sub(r"(\d{2})[UuXx]{2}", r"\1--?", value)
+    # Single U/u/X/x: 197u -> 197-
+    value = re.sub(r"(\d{3})[UuXx]", r"\1-", value)
+    return value
+
+
+def _normalize_date_ranges(value: str) -> str:
+    """Normalize date ranges to a consistent format, if possible."""
+    # Slash range: 1955/1956 -> 1955-1956
+    value = re.sub(r"(\d{4})/(\d{4})", r"\1-\2", value)
+    # Bracket range: [1975-76] -> 1975-1976
+    value = re.sub(
+        r"\[(\d{4})-(\d{2})\]",
+        lambda m: f"{m.group(1)}-{m.group(1)[:2]}{m.group(2)}",
+        value,
+    )
+    # Spaced dash: 1959 - 1963 -> 1959-1963
+    value = re.sub(r"(\d{4})\s*-\s*(\d{4})", r"\1-\2", value)
+    # Two-digit second year: Assume same century as first year: 1975-76 -> 1975-1976
+    # Only expand two-digit second years when they are unlikely to be months
+    # (e.g., 76 -> 1976). If the second group looks like a month (01-12), leave it alone.
+
+    def _expand_two_digit_year(m):
+        y1 = m.group(1)
+        y2 = m.group(2)
+        try:
+            n = int(y2)
+        except ValueError:
+            return m.group(0)
+        if 1 <= n <= 12:
+            return m.group(0)
+        return f"{y1}-{y1[:2]}{y2}"
+
+    value = re.sub(r"(\d{4})-(\d{2})\b", _expand_two_digit_year, value)
+    return value.strip()
+
+
 # These list out the transformers to apply for each target field.
 # We can reuse generic transformers, but apply them in different orders if need be.
 TRANSFORMERS = {
@@ -409,6 +615,28 @@ TRANSFORMERS = {
         _parse_credited_names,
         _standardize_director_name,
         lambda value: MAPPINGS["director"].get(value.upper(), value),
+    ],
+    "record_date": [
+        _trim_whitespace,
+        lambda value: MAPPINGS["date"].get(value, value),
+        _remove_brackets,
+        _convert_natural_language_date,
+        _normalize_copyright_and_circa,
+        _normalize_date_format,
+        _handle_partial_years,
+        _handle_U_X_placeholders,
+        _normalize_date_ranges,
+    ],
+    "release_broadcast_date": [
+        _trim_whitespace,
+        lambda value: MAPPINGS["date"].get(value, value),
+        _remove_brackets,
+        _convert_natural_language_date,
+        _normalize_copyright_and_circa,
+        _normalize_date_format,
+        _handle_partial_years,
+        _handle_U_X_placeholders,
+        _normalize_date_ranges,
     ],
 }
 

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -2,6 +2,8 @@ import tomllib
 import logging
 import argparse
 import re
+import dateparser
+from edtf import parse_edtf, EDTFParseException
 from enum import StrEnum
 from string import capwords
 from strsimpy.normalized_levenshtein import NormalizedLevenshtein
@@ -400,7 +402,11 @@ def _normalize_language_spelling(value: str) -> str:
 
 def _remove_brackets(value: str) -> str:
     """Remove square brackets and parentheses from the provided value, if present."""
-    return re.sub(r"[\[\]\(\)]", "", value).strip()
+    if not value:
+        return ""
+    v = value.replace("[", "").replace("]", "")
+    v = v.replace("(", "").replace(")", "")
+    return v.strip()
 
 
 def _normalize_copyright_and_circa(value: str) -> str:
@@ -423,104 +429,105 @@ def _normalize_copyright_and_circa(value: str) -> str:
     return value.strip()
 
 
-def _convert_natural_language_date(value: str) -> str:
-    """Convert natural language date expressions to a standardized format, if possible."""
-    # Only process if value starts with a month name (not a number)
+def _normalize_date(value: str) -> str:
+    """Normalize dates using EDTF (for uncertainty/unknown digits/ranges) with a
+    fallback to dateparser for natural-language dates.
+    """
+    v = (value or "").strip()
+    # If no value, or if value doesn't contain any digits, return early
+    if not v or not re.search(r"\d", v):
+        return v
+
+    # Apply partial-year and placeholder/range normalizers first so we don't
+    # accidentally let a short numeric string be parsed as a day/month.
+    # Note: run partial-year handling before replacing U/X so we can distinguish
+    # explicit trailing hyphens from ones created by placeholder replacement.
+    v = _handle_partial_years(v)
+    v = _handle_U_X_placeholders(v)
+    v = _normalize_date_ranges(v)
+
+    # If the value begins with a month name, prefer `dateparser` to produce
+    # YYYY-MM or YYYY-MM-DD (avoid regex-heavy transformations here).
     month_regex = (
         r"^(January|February|March|April|May|June|July|August|September|October|November|December|"
         r"Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\b"
     )
-    if not re.match(month_regex, value, re.IGNORECASE):
-        return value.strip()
+    if re.match(month_regex, v, re.IGNORECASE):
+        try:
+            # Use `PREFER_DAY_OF_MONTH: 'first'` so ambiguous month+year
+            # expressions (e.g. "Jan 1956") produce a stable canonical
+            # representation. We prefer YYYY-MM when a day is not present,
+            # but when a day is present we want a full YYYY-MM-DD. This
+            # setting ensures `dateparser` chooses the first day of the
+            # month rather than attempting to infer the day.
+            dt = dateparser.parse(v, settings={"PREFER_DAY_OF_MONTH": "first"})
+            if dt:
+                # If original contains an explicit day number, return full date
+                if re.search(r"\b\d{1,2}\b", v):
+                    v = dt.date().isoformat()
+                else:
+                    v = f"{dt.year:04d}-{dt.month:02d}"
+        except (ValueError, TypeError, OverflowError):
+            pass
 
-    month_map = {
-        "january": "01",
-        "jan": "01",
-        "february": "02",
-        "feb": "02",
-        "march": "03",
-        "mar": "03",
-        "april": "04",
-        "apr": "04",
-        "may": "05",
-        "june": "06",
-        "jun": "06",
-        "july": "07",
-        "jul": "07",
-        "august": "08",
-        "aug": "08",
-        "september": "09",
-        "sep": "09",
-        "sept": "09",
-        "october": "10",
-        "oct": "10",
-        "november": "11",
-        "nov": "11",
-        "december": "12",
-        "dec": "12",
-    }
-
-    def month_day_year_sub(m):
-        month_name = m.group(1).lower()
-        month = (
-            month_map[month_name]
-            if month_name in month_map
-            else month_map[month_name[:3]]
-        )
-        day = int(m.group(2))
-        year = m.group(3)
-        return f"{year}-{month}-{day:02d}"
-
-    value = re.sub(
-        r"\b(January|February|March|April|May|June|July|August|September|October|November|December|"
-        r"Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\s+(\d{1,2})\s*,?\s*(\d{4})\b",
-        month_day_year_sub,
-        value,
-        flags=re.IGNORECASE,
-    )
-
-    def month_year_sub(m):
-        month_name = m.group(1).lower()
-        month = (
-            month_map[month_name]
-            if month_name in month_map
-            else month_map[month_name[:3]]
-        )
-        year = m.group(2)
-        return f"{year}-{month}"
-
-    value = re.sub(
-        r"\b(January|February|March|April|May|June|July|August|September|October|November|December|"
-        r"Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\s+(\d{4})\b",
-        month_year_sub,
-        value,
-        flags=re.IGNORECASE,
-    )
-    return value.strip()
-
-
-def _normalize_date_format(value: str) -> str:
-    """Converts various date formats to a standardized YYYY-MM-DD or YYYY-MM format, if possible."""
-    # Strip whitespace before checking for normalized format
-    value_stripped = value.strip()
-    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", value_stripped) or re.fullmatch(
-        r"\d{4}-\d{2}", value_stripped
-    ):
-        return value_stripped
-
+    # Normalize common numeric date formats using `dateparser` where possible
     # MM/DD/YYYY or MM-DD-YYYY -> YYYY-MM-DD
-    value = re.sub(
-        r"\b(\d{1,2})[/-](\d{1,2})[/-](\d{4})\b",
-        lambda m: f"{m.group(3)}-{int(m.group(1)):02d}-{int(m.group(2)):02d}",
-        value,
-    )
-    # MM/YYYY or MM-YYYY -> YYYY-MM
-    value = re.sub(
-        r"\b(\d{1,2})[/-](\d{4})\b",
-        lambda m: f"{m.group(2)}-{int(m.group(1)):02d}",
-        value,
-    )
-    return value.strip()
+    if re.search(r"\b\d{1,2}[/-]\d{1,2}[/-]\d{4}\b", v):
+        try:
+            # For explicit numeric dates, set `PREFER_DAY_OF_MONTH` to keep
+            # parsing deterministic (choose first-of-month when needed).
+            dt = dateparser.parse(v, settings={"PREFER_DAY_OF_MONTH": "first"})
+            if dt:
+                return dt.date().isoformat()
+        except (ValueError, TypeError, OverflowError):
+            pass
+
+    # MM/YYYY or MM-YYYY -> YYYY-MM (preserve month precision)
+    m = re.search(r"\b(\d{1,2})[/-](\d{4})\b", v)
+    if m:
+        month = int(m.group(1))
+        year = int(m.group(2))
+        if 1 <= month <= 12:
+            return f"{year:04d}-{month:02d}"
+
+    # Preserve copyright-like values such as 'c1978' (should not be parsed into a date)
+    if re.fullmatch(r"c\d{4}\??", v, flags=re.IGNORECASE):
+        return v
+
+    # If we already have a normalized YYYY-MM or YYYY-MM-DD or range, return it
+    if re.fullmatch(r"\d{4}-\d{2}(-\d{2})?", v) or re.fullmatch(r"\d{4}-\d{4}", v):
+        return v
+
+    # Try EDTF parsing/validation next (handles u-placements, ? and ranges)
+    v_edtf = re.sub(r"[UuXx]", "u", v)
+    try:
+        parsed = parse_edtf(v_edtf)
+        if parsed:
+            return str(parsed)
+    except EDTFParseException:
+        pass
+
+    # As a last resort, attempt natural-language parsing but only when the
+    # input looks like it contains explicit day or month text (avoid interpreting
+    # short numeric strings as days).
+    try:
+        # Only call dateparser when the transformed value looks like a
+        # natural-language date (avoid interpreting short or placeholder
+        # strings as current-month dates). Use `v` (the transformed value).
+        if re.search(r"[A-Za-z]|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}", v):
+            # Make deterministic day selection (first) to avoid
+            # unpredictable results when only month/year is present.
+            dt = dateparser.parse(v, settings={"PREFER_DAY_OF_MONTH": "first"})
+            if dt:
+                # If transformed value had a month name with no day, prefer YYYY-MM
+                if re.search(r"[A-Za-z]", v) and not re.search(r"\b\d{1,2}\b", v):
+                    return f"{dt.year:04d}-{dt.month:02d}"
+                return dt.date().isoformat()
+    except (ValueError, TypeError, OverflowError):
+        pass
+
+    # If nothing matched, return the (possibly transformed) value
+    return v
 
 
 def _handle_partial_years(value: str) -> str:
@@ -575,19 +582,24 @@ def _normalize_date_ranges(value: str) -> str:
     # Only expand two-digit second years when they are unlikely to be months
     # (e.g., 76 -> 1976). If the second group looks like a month (01-12), leave it alone.
 
-    def _expand_two_digit_year(m):
-        y1 = m.group(1)
-        y2 = m.group(2)
-        try:
-            n = int(y2)
-        except ValueError:
-            return m.group(0)
-        if 1 <= n <= 12:
-            return m.group(0)
-        return f"{y1}-{y1[:2]}{y2}"
-
     value = re.sub(r"(\d{4})-(\d{2})\b", _expand_two_digit_year, value)
     return value.strip()
+
+
+def _expand_two_digit_year(m: re.Match) -> str:
+    """Helper function for _normalize_date_ranges to expand two-digit
+    second years in date ranges."""
+    # Only expand if the second group is not a valid month (01-12);
+    # otherwise, return original string.
+    y1 = m.group(1)
+    y2 = m.group(2)
+    try:
+        n = int(y2)
+    except ValueError:
+        return m.group(0)
+    if 1 <= n <= 12:
+        return m.group(0)
+    return f"{y1}-{y1[:2]}{y2}"
 
 
 # These list out the transformers to apply for each target field.
@@ -620,23 +632,15 @@ TRANSFORMERS = {
         _trim_whitespace,
         lambda value: MAPPINGS["date"].get(value, value),
         _remove_brackets,
-        _convert_natural_language_date,
         _normalize_copyright_and_circa,
-        _normalize_date_format,
-        _handle_partial_years,
-        _handle_U_X_placeholders,
-        _normalize_date_ranges,
+        _normalize_date,
     ],
     "release_broadcast_year": [
         _trim_whitespace,
         lambda value: MAPPINGS["date"].get(value, value),
         _remove_brackets,
-        _convert_natural_language_date,
         _normalize_copyright_and_circa,
-        _normalize_date_format,
-        _handle_partial_years,
-        _handle_U_X_placeholders,
-        _normalize_date_ranges,
+        _normalize_date,
     ],
 }
 
@@ -765,9 +769,6 @@ def _initialize_client(config: dict) -> FilemakerClient:
             timeout=240,
         )
         logger.info("Connected to Filemaker.")
-        print(
-            client._fms
-        )  # Log the internal FilemakerServer instance for debugging connection issues
         return client
     except FileMakerError as e:
         logger.error(f"Failed to connect to Filemaker: {e}")

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -413,8 +413,7 @@ def _normalize_copyright_and_circa(value: str) -> str:
     """Normalize various representations of "Copyright" and "Circa" in the provided value."""
     # Copyright: Standardize to lowercase c followed immediately by year.
     # c 1978, C1988, COPYRIGHT 2007 -> c1978, c1988, c2007
-    copyright_pattern = re.compile(r"c(?:opyright)?\.?\s*(\d{4})", re.IGNORECASE)
-    value = copyright_pattern.sub(r"c\1", value)
+    value = re.sub(r"(?i)c(?:opyright)?\.?\s*(\d{4})", r"c\1", value)
 
     # Circa: Replace circa, ca., CA., CIRCA, c. with question mark after year
     # Exception: Convert circa date range to “or” format first
@@ -433,18 +432,25 @@ def _normalize_date(value: str) -> str:
     """Normalize dates using EDTF (for uncertainty/unknown digits/ranges) with a
     fallback to dateparser for natural-language dates.
     """
-    v = (value or "").strip()
+    value = (value or "").strip()
+    # If value contains multiple full numeric dates separated by commas, leave as-is
+    # e.g. "11-12-1959, 11-19-1959" or "04/02/1959, 04/09/1959"
+    if "," in value:
+        multi_dates = re.findall(r"\b\d{1,2}[/-]\d{1,2}[/-]\d{4}\b", value)
+        if len(multi_dates) > 1:
+            return value
     # If no value, or if value doesn't contain any digits, return early
-    if not v or not re.search(r"\d", v):
-        return v
+    if not value or not re.search(r"\d", value):
+        return value
 
     # Preserve copyright-like values such as 'c1978' (should not be parsed into a date)
-    if re.fullmatch(r"c\d{4}\??", v, flags=re.IGNORECASE):
-        return v
-
+    if re.fullmatch(r"c\d{4}\??", value, flags=re.IGNORECASE):
+        return value
     # If we already have a normalized YYYY-MM or YYYY-MM-DD or range, return it
-    if re.fullmatch(r"\d{4}-\d{2}(-\d{2})?", v) or re.fullmatch(r"\d{4}-\d{4}", v):
-        return v
+    if re.fullmatch(r"\d{4}-\d{2}(-\d{2})?", value) or re.fullmatch(
+        r"\d{4}-\d{4}", value
+    ):
+        return value
 
     # If the value begins with a month name, prefer `dateparser` to produce
     # YYYY-MM or YYYY-MM-DD (avoid regex-heavy transformations here).
@@ -458,38 +464,38 @@ def _normalize_date(value: str) -> str:
     day_range_regex = (
         rf"^({month_names})\b\s+\d{{1,2}}\s*[-–]\s*\d{{1,2}}(?:\s*,\s*\d{{4}})?$"
     )
-    if re.match(day_range_regex, v, re.IGNORECASE):
-        return v
+    if re.match(day_range_regex, value, re.IGNORECASE):
+        return value
 
     month_regex = rf"^({month_names})\b"
-    if re.match(month_regex, v, re.IGNORECASE):
+    if re.match(month_regex, value, re.IGNORECASE):
         try:
             # Use `PREFER_DAY_OF_MONTH: 'first'` so dateparser always uses the
             # first of the month rather than attempting to infer the day.
-            dt = dateparser.parse(v, settings={"PREFER_DAY_OF_MONTH": "first"})
+            dt = dateparser.parse(value, settings={"PREFER_DAY_OF_MONTH": "first"})
             if dt:
                 # If original contains an explicit day number, return full date
-                if re.search(r"\b\d{1,2}\b", v):
-                    v = dt.date().isoformat()
+                if re.search(r"\b\d{1,2}\b", value):
+                    value = dt.date().isoformat()
                 else:
-                    v = f"{dt.year:04d}-{dt.month:02d}"
+                    value = f"{dt.year:04d}-{dt.month:02d}"
         except (ValueError, TypeError, OverflowError):
             pass
 
     # Normalize common numeric date formats using `dateparser` where possible
     # MM/DD/YYYY or MM-DD-YYYY -> YYYY-MM-DD
-    if re.search(r"\b\d{1,2}[/-]\d{1,2}[/-]\d{4}\b", v):
+    if re.search(r"\b\d{1,2}[/-]\d{1,2}[/-]\d{4}\b", value):
         try:
             # For explicit numeric dates, set `PREFER_DAY_OF_MONTH` to keep
             # parsing deterministic (choose first-of-month when needed).
-            dt = dateparser.parse(v, settings={"PREFER_DAY_OF_MONTH": "first"})
+            dt = dateparser.parse(value, settings={"PREFER_DAY_OF_MONTH": "first"})
             if dt:
                 return dt.date().isoformat()
         except (ValueError, TypeError, OverflowError):
             pass
 
     # MM/YYYY or MM-YYYY -> YYYY-MM (preserve month precision)
-    m = re.search(r"\b(\d{1,2})[/-](\d{4})\b", v)
+    m = re.search(r"\b(\d{1,2})[/-](\d{4})\b", value)
     if m:
         month = int(m.group(1))
         year = int(m.group(2))
@@ -497,7 +503,7 @@ def _normalize_date(value: str) -> str:
             return f"{year:04d}-{month:02d}"
 
     # Try EDTF parsing/validation next (handles u-placements, ? and ranges)
-    v_edtf = re.sub(r"[UuXx]", "u", v)
+    v_edtf = re.sub(r"[UuXx]", "u", value)
     try:
         parsed = parse_edtf(v_edtf)
         if parsed:
@@ -511,21 +517,23 @@ def _normalize_date(value: str) -> str:
     try:
         # Only call dateparser when the transformed value looks like a
         # natural-language date (avoid interpreting short or placeholder
-        # strings as current-month dates). Use v, the value after transformations.
-        if re.search(r"[A-Za-z]|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}", v):
+        # strings as current-month dates). Use value, the value after transformations.
+        if re.search(r"[A-Za-z]|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}", value):
             # Make deterministic day selection (first) to avoid
             # unpredictable results when only month/year is present.
-            dt = dateparser.parse(v, settings={"PREFER_DAY_OF_MONTH": "first"})
+            dt = dateparser.parse(value, settings={"PREFER_DAY_OF_MONTH": "first"})
             if dt:
                 # If transformed value had a month name with no day, prefer YYYY-MM
-                if re.search(r"[A-Za-z]", v) and not re.search(r"\b\d{1,2}\b", v):
+                if re.search(r"[A-Za-z]", value) and not re.search(
+                    r"\b\d{1,2}\b", value
+                ):
                     return f"{dt.year:04d}-{dt.month:02d}"
                 return dt.date().isoformat()
     except (ValueError, TypeError, OverflowError):
         pass
 
     # If nothing matched, return the (possibly transformed) value
-    return v
+    return value
 
 
 def _handle_partial_years(value: str) -> str:
@@ -623,6 +631,8 @@ TRANSFORMERS = {
         _standardize_director_name,
         lambda value: MAPPINGS["director"].get(value.upper(), value),
     ],
+    # Both date fields (record_date and release_broadcast_year) use the same sequence of
+    # transformers, listed separately here to maintain one-to-one mapping with FM fields.
     "record_date": [
         _trim_whitespace,
         lambda value: MAPPINGS["date"].get(value, value),
@@ -848,7 +858,7 @@ def _process_record(
                 logger.debug(
                     f"NO CHANGE field_name={field_name} "
                     f"record_id={record_id} inventory_id={inventory_id} "
-                    f"from={current_value!r} to={(new_value or '')!r}"
+                    f"from={current_value!r} to={(new_value)!r}"
                 )
             continue
 

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -845,7 +845,7 @@ def _process_record(
         if current_value == new_value:  # skip if no change
             continue
 
-        logger.info(
+        logger.debug(
             f"UPDATE field_name={field_name} "
             f"record_id={record_id} inventory_id={inventory_id} "
             f"from={current_value!r} to={(new_value or '')!r}"  # use `!r` so `\r` is visible in log

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -500,7 +500,7 @@ def _normalize_date(value: str) -> str:
             except (ValueError, TypeError, OverflowError):
                 return value
         else:
-            logger.warning(
+            logger.debug(
                 f"Two-digit year {yy:02d} in {value!r} <= cutoff {cutoff:02d}; left unchanged."
             )
             return value

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -843,6 +843,13 @@ def _process_record(
         new_value = _apply_transformers(field_name, current_value)
 
         if current_value == new_value:  # skip if no change
+            # If the values are not blank, log a message to aid in review
+            if current_value != "":
+                logger.debug(
+                    f"NO CHANGE field_name={field_name} "
+                    f"record_id={record_id} inventory_id={inventory_id} "
+                    f"from={current_value!r} to={(new_value or '')!r}"
+                )
             continue
 
         logger.debug(

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -484,6 +484,13 @@ def _normalize_date(value: str) -> str:
     # Handle two-digit year forms specially per Y2K-like rule: if the two-digit
     # year is greater than the last two digits of the current year, interpret
     # as 19YY; otherwise leave unchanged and log a warning for manual review.
+    # Avoid accidental matches inside strings that actually contain four
+    # numeric components (e.g. '08-15-16-1991' or '4/23-25/1993') by returning
+    # early when 4+ numeric components are present.
+    comps = re.split(r"[/-]", value)
+    numeric_comps = [c for c in comps if re.fullmatch(r"\d+", c)]
+    if len(numeric_comps) >= 4:
+        return value
     m_two = re.search(r"\b(\d{1,2})[/-](\d{1,2})[/-](\d{2})\b", value)
     if m_two:
         month = int(m_two.group(1))
@@ -501,7 +508,7 @@ def _normalize_date(value: str) -> str:
                 return value
         else:
             logger.debug(
-                f"Two-digit year {yy:02d} in {value!r} <= cutoff {cutoff:02d}; left unchanged."
+                f"Two-digit year in {value!r} <= {cutoff:02d}; left unchanged."
             )
             return value
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ strsimpy==0.2.1
 git+https://github.com/UCLALibrary/alma-api-client
 # For retrying requests to Filemaker API
 retry==0.9.2
+# For date parsing
+edtf==5.0.1
+dateparser==1.4.0

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -192,7 +192,9 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             ("n/a", "N/A"),  # special case, known value
             ("UUUU", "Unknown"),  # special case, known value
             ("nd", "Unknown"),  # special case, known value
-            ("?", "Unknown"),  # special casem known value
+            ("?", "Unknown"),  # special case, known value
+            ("uuuu", "Unknown"),  # special case, known value
+            ("", "Unknown"),  # empty value
             ("[1992]", "1992"),  # brackets should be removed
             ("(1992)", "1992"),  # parentheses should be removed
             ("c 1939", "c1939"),  # normalize copyright format
@@ -211,6 +213,7 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             ("06/15/1980", "1980-06-15"),  # normalize date format
             ("03-25-1990", "1990-03-25"),
             ("04/1985", "1985-04"),
+            ("01/00/1951", "1951-01"),  # handle zero day/month as unknown
             ("19", "19--?"),  # partial year with two digits
             ("20-", "20--"),  # partial year with two digits and trailing hyphen
             ("195-", "195-"),  # partial year with three digits but no question mark
@@ -228,7 +231,13 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             ("20XX", "20--?"),
             ("19uu-1971", "19--?-1971"),  # handle partial year ranges with placeholders
             ("19UU-UUUU", "19--?"),  # partial range, collapses to single indeterminate
-            ("1955/1956", "1955-1956"),  # handle various date range formats
+            ("193U-UUUU", "193-?"),  # partial range with placeholders
+            (
+                "1959-UUUU",
+                "1959",
+            ),  # partial range with known start year should collapse to that year
+            ("1955/1956", "1955/1956"),  # don't modify slash-delimited date ranges
+            ("1984/1977/1978", "1984/1977/1978"),
             ("[2011-13]", "2011-2013"),
             ("1959 - 1963", "1959-1963"),
             ("1975-76", "1975-1976"),

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -275,6 +275,16 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
                 "c 1978.",
                 "c1978",
             ),  # period after year should be removed in copyright format
+            (
+                "12/10/59",
+                "1959-12-10",
+            ),  # two-digit year > 26 should be treated as 1900s, not 2000s
+            ("12-10-59", "1959-12-10"),
+            (
+                "12/10/25",
+                "12/10/25",
+            ),  # two-digit year <= 26 should be unchanged
+            ("12-10-25", "12-10-25"),
         ]
 
     def test_production_type_mapping(self):
@@ -300,3 +310,14 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             with self.subTest(input=input, expected=expected):
                 new_value = _apply_transformers("record_date", input)
                 self.assertEqual(new_value, expected)
+
+    def test_two_digit_year_warning(self):
+        # Two-digit year <= cutoff should be left unchanged and log a warning
+        val = "12/10/25"
+        with self.assertLogs("filemaker_batch_update", level="WARNING") as cm:
+            new_value = _apply_transformers("record_date", val)
+        self.assertEqual(new_value, val)
+        # Ensure a warning was emitted about the two-digit year handling
+        self.assertTrue(
+            any("Two-digit year" in m or "left unchanged" in m for m in cm.output)
+        )

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -237,6 +237,7 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             ("JUNE 28-29", "JUNE 28-29"),  # date range of days should not be modified
             ("MAY 9-10, 1980", "MAY 9-10, 1980"),
             ("APRIL 30 & MAY 1-3, 1980", "APRIL 30 & MAY 1-3, 1980"),
+            ("October 17 & 18, 1989", "October 17 & 18, 1989"),
             ("MAY 7,8 & 9", "MAY 7,8 & 9"),
             ("FALL 1978", "FALL 1978"),  # season and year should not be modified
             (
@@ -244,6 +245,27 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
                 "11-12-1959, 11-19-1959",
             ),  # don't modify lists of dates
             ("04-02-1959, 04-09-1959", "04-02-1959, 04-09-1959"),
+            (
+                "C. 1970s",
+                "197-?",
+            ),  # decade with circa should be normalized to decade format
+            (
+                "ca. 1920’s?",
+                "192-?",
+            ),  # decade with circa and question mark should be normalized to decade format
+            (
+                "1960-1970s",
+                "1960-1970",
+            ),  # decade range should be normalized to decade format
+            (
+                "10-09-1995\r10-14-2002",
+                "10-09-1995\r10-14-2002",
+            ),  # multiple dates separated by carriage return should not be modified
+            ("1924 circa", "1924?"),  # circa after date should be normalized
+            (
+                "c 1978.",
+                "c1978",
+            ),  # period after year should be removed in copyright format
         ]
 
     def test_production_type_mapping(self):

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -285,6 +285,14 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
                 "12/10/25",
             ),  # two-digit year <= 26 should be unchanged
             ("12-10-25", "12-10-25"),
+            (
+                "08-15-16-1959",
+                "08-15-16-1959",
+            ),  # invalid date with extra component should not be modified
+            (
+                "4/23-25/1993",
+                "4/23-25/1993",
+            ),  # date range with day and month should not be modified
         ]
 
     def test_production_type_mapping(self):
@@ -314,10 +322,8 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
     def test_two_digit_year_warning(self):
         # Two-digit year <= cutoff should be left unchanged and log a warning
         val = "12/10/25"
-        with self.assertLogs("filemaker_batch_update", level="WARNING") as cm:
+        with self.assertLogs("filemaker_batch_update", level="DEBUG") as cm:
             new_value = _apply_transformers("record_date", val)
         self.assertEqual(new_value, val)
-        # Ensure a warning was emitted about the two-digit year handling
-        self.assertTrue(
-            any("Two-digit year" in m or "left unchanged" in m for m in cm.output)
-        )
+        # Ensure a message was logged about the two-digit year handling
+        self.assertTrue(any("Two-digit year" in m for m in cm.output))

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -185,6 +185,50 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
                 "1. John A.B.C. Doe, Jane Star, LeeRoy Jenkins",
             ),  # composite test: multiple transformations
         ]
+        self.test_date_values = [
+            ("1974 ", "1974"),  # trailing whitespace
+            ("n/a", "N/A"),  # special case, known value
+            ("UUUU", "Unknown"),  # special case, known value
+            ("nd", "Unknown"),  # special case, known value
+            ("?", "Unknown"),  # special casem known value
+            ("[1992]", "1992"),  # brackets should be removed
+            ("(1992)", "1992"),  # parentheses should be removed
+            ("c 1939", "c1939"),  # normalize copyright format
+            ("COPYRIGHT 2007", "c2007"),
+            ("C1988", "c1988"),
+            ("c1978", "c1978"),
+            ("CIRCA 1970", "1970?"),  # normalize circa format
+            ("ca. 1950", "1950?"),
+            ("CA. 2020", "2020?"),
+            ("circa 1925", "1925?"),
+            ("circa 1920-1930", "1920 or 1930"),  # circa range format
+            ("January 1956", "1956-01"),  # convert natural language date
+            ("Feb 1967", "1967-02"),
+            ("Mar 24 1953", "1953-03-24"),
+            ("June 28, 1975", "1975-06-28"),
+            ("06/15/1980", "1980-06-15"),  # normalize date format
+            ("03-25-1990", "1990-03-25"),
+            ("04/1985", "1985-04"),
+            ("19", "19--?"),  # partial year with two digits
+            ("20-", "20--"),  # partial year with two digits and trailing hyphen
+            ("195-", "195-?"),  # partial year with three digits
+            ("1990s", "199-"),  # decade
+            ("19??", "19--?"),  # partial year with two digits and question marks
+            ("1946?", "1946?"),  # partial year with four digits and ?, no modification
+            ("195?", "195?"),  # partial year with three digits and ?, no modification
+            ("197u", "197-"),  # partial year with single u/x placeholder
+            ("20UU", "20--?"),  # partial year with two placeholders
+            ("19uu", "19--?"),
+            ("20XX", "20--?"),
+            ("19uu-1971", "19--?-1971"),  # handle partial year ranges with placeholders
+            ("19UU-UUUU", "19--?"),  # partial range, collapses to single indeterminate
+            ("1955/1956", "1955-1956"),  # handle various date range formats
+            ("[2011-13]", "2011-2013"),
+            ("1959 - 1963", "1959-1963"),
+            ("1975-76", "1975-1976"),
+            ("2015-03-12", "2015-03-12"),  # valid date, no transform needed
+            ("1939-11-28", "1939-11-28"),
+        ]
 
     def test_production_type_mapping(self):
         for input, expected in self.test_production_type_values:
@@ -202,4 +246,10 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
         for input, expected in self.test_director_values:
             with self.subTest(input=input, expected=expected):
                 new_value = _apply_transformers("director", input)
+                self.assertEqual(new_value, expected)
+
+    def test_date_mapping(self):
+        for input, expected in self.test_date_values:
+            with self.subTest(input=input, expected=expected):
+                new_value = _apply_transformers("release_broadcast_date", input)
                 self.assertEqual(new_value, expected)

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -251,5 +251,5 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
     def test_date_mapping(self):
         for input, expected in self.test_date_values:
             with self.subTest(input=input, expected=expected):
-                new_value = _apply_transformers("release_broadcast_date", input)
+                new_value = _apply_transformers("record_date", input)
                 self.assertEqual(new_value, expected)

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -186,6 +186,8 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             ),  # composite test: multiple transformations
         ]
         self.test_date_values = [
+            ("1999", "1999"),  # valid year, no transform needed
+            ("1999-01-01", "1999-01-01"),  # valid date, no transform needed
             ("1974 ", "1974"),  # trailing whitespace
             ("n/a", "N/A"),  # special case, known value
             ("UUUU", "Unknown"),  # special case, known value
@@ -237,6 +239,11 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             ("APRIL 30 & MAY 1-3, 1980", "APRIL 30 & MAY 1-3, 1980"),
             ("MAY 7,8 & 9", "MAY 7,8 & 9"),
             ("FALL 1978", "FALL 1978"),  # season and year should not be modified
+            (
+                "11-12-1959, 11-19-1959",
+                "11-12-1959, 11-19-1959",
+            ),  # don't modify lists of dates
+            ("04-02-1959, 04-09-1959", "04-02-1959, 04-09-1959"),
         ]
 
     def test_production_type_mapping(self):

--- a/tests/test_filemaker_batch_update.py
+++ b/tests/test_filemaker_batch_update.py
@@ -211,7 +211,11 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             ("04/1985", "1985-04"),
             ("19", "19--?"),  # partial year with two digits
             ("20-", "20--"),  # partial year with two digits and trailing hyphen
-            ("195-", "195-?"),  # partial year with three digits
+            ("195-", "195-"),  # partial year with three digits but no question mark
+            (
+                "196-?",
+                "196-?",
+            ),  # partial year with three digits, dash, and question mark, no modification
             ("1990s", "199-"),  # decade
             ("19??", "19--?"),  # partial year with two digits and question marks
             ("1946?", "1946?"),  # partial year with four digits and ?, no modification
@@ -228,6 +232,11 @@ class TestFilemakerBatchUpdate(unittest.TestCase):
             ("1975-76", "1975-1976"),
             ("2015-03-12", "2015-03-12"),  # valid date, no transform needed
             ("1939-11-28", "1939-11-28"),
+            ("JUNE 28-29", "JUNE 28-29"),  # date range of days should not be modified
+            ("MAY 9-10, 1980", "MAY 9-10, 1980"),
+            ("APRIL 30 & MAY 1-3, 1980", "APRIL 30 & MAY 1-3, 1980"),
+            ("MAY 7,8 & 9", "MAY 7,8 & 9"),
+            ("FALL 1978", "FALL 1978"),  # season and year should not be modified
         ]
 
     def test_production_type_mapping(self):


### PR DESCRIPTION
Implements [DLSR-246](https://uclalibrary.atlassian.net/browse/DLSR-246)
Relevant specs: https://uclalibrary.atlassian.net/wiki/x/GQBOZw

Adds support for normalizing two new FM fields, `release_broadcast_year` and `record_date`, using the same logical rules. I am running a full dry run of the script now and will provide the output log file with all intended updates (and non-updates of non-empty values) in Slack tomorrow.

For a full dry run: `docker compose exec ftva_data python filemaker_batch_update.py -c prod_config_secrets.toml -f release_broadcast_year record_date --dry_run`

For tests: `docker compose exec ftva_data python -m unittest`
 
When running the script or tests, you may see a message about `tzlocal` awkwardly placed in the terminal output. I believe this is coming from one of the two date parsing libraries, but I didn't find a quick way to silence it.

This is a complicated set of requirements, and the code relies on many complex regexes (created with assistance from LLMs). To try to compensate for this opacity, I've added a large number of tests, most of which use values found in the database. I've also added the `edtf` and `dateparser` libraries, which are helpful in a limited set of cases.

[DLSR-246]: https://uclalibrary.atlassian.net/browse/DLSR-246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ