### PR TITLE
DLSR-323: Improve timeouts and restarts in batch update script

### DIFF
--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -99,6 +99,13 @@ def _get_arguments() -> argparse.Namespace:
         required=False,
         help="Page size (i.e. `limit` param) for fetching records from Filemaker. Default is 5000.",
     )
+    parser.add_argument(
+        "--offset",
+        type=int,
+        default=1,
+        required=False,
+        help="Offset (position in list of records, NOT `record_id`) to start fetching records from Filemaker. Default is 1.",
+    )
     return parser.parse_args()
 
 
@@ -889,14 +896,17 @@ def _validate_fields(field_names: list[str], fm_record: Record) -> None:
         )
 
 
-def _get_all_records(fm_client: FilemakerClient, page_size: int) -> Iterator[Record]:
+def _get_all_records(
+    fm_client: FilemakerClient, page_size: int, offset: int = 1
+) -> Iterator[Record]:
     """Yield every record in the Filemaker database, paginating automatically.
 
     :param fm_client: A configured FilemakerClient instance.
+    :param page_size: Number of records to retrieve at a time.
+    :param offset: Position (NOT record_id) to start at. Default: 1.
     :yields: Individual fmrest `Record` objects.
     """
     logger.info(f"Retrieving records in pages of {page_size}...")
-    offset = 1
     while True:
         records = fm_client.get_records(
             offset=offset,
@@ -1007,6 +1017,7 @@ def _process_batch(
     fm_client: FilemakerClient,
     dry_run: bool,
     page_size: int,
+    offset: int = 1,
 ) -> dict[str, int]:
     """Apply transformations to the provided fields on the Filemaker records.
 
@@ -1014,6 +1025,7 @@ def _process_batch(
     :param fm_client: Configured `FilemakerClient` instance.
     :param dry_run: If True, log changes without writing to Filemaker.
     :param page_size: Page size (i.e. `limit` param) for fetching records from Filemaker.
+    :param offset: Position (NOT record_id) to start at. Default: 1.
     :return: Stats summarizing records processed, updated, and changes applied.
     """
     stats = {
@@ -1024,7 +1036,7 @@ def _process_batch(
     }
     fields_validated = False
 
-    for fm_record in _get_all_records(fm_client, page_size):
+    for fm_record in _get_all_records(fm_client, page_size, offset):
         # Validate fields against first record.
         # Invalid fields will raise an exception and cause the program to exit,
         # with a message explaining which fields are missing and which are available.
@@ -1071,7 +1083,7 @@ def main() -> None:
     fm_client = _initialize_client(config)
 
     stats = _process_batch(
-        fields_with_transformers, fm_client, args.dry_run, args.page_size
+        fields_with_transformers, fm_client, args.dry_run, args.page_size, args.offset
     )
 
     action = "Would update" if args.dry_run else "Updated"

--- a/filemaker_batch_update.py
+++ b/filemaker_batch_update.py
@@ -857,11 +857,13 @@ def _initialize_client(config: dict) -> FilemakerClient:
     :return: An initialized `FilemakerClient` instance.
     :raises FileMakerError: If the connection to Filemaker fails.
     """
+    # Get the filemaker-specific configuration dictionary.
+    fm_config = config.get("filemaker", {})
     try:
         client = FilemakerClient(
-            user=config["filemaker"]["user"],
-            password=config["filemaker"]["password"],
-            timeout=240,
+            user=fm_config.get("user", ""),
+            password=fm_config.get("password", ""),
+            timeout=fm_config.get("timeout", 120),  # default to 2 minute timeout
         )
         logger.info("Connected to Filemaker.")
         return client
@@ -955,6 +957,10 @@ def _process_record(
         pending_changes[field_name] = new_value
 
     if pending_changes and not dry_run:
+        # Hacky attempt to work around timeouts with updates.
+        # These usually are very brief interruptions, no need to wait more than a few seconds.
+        old_timeout = fm_client._fms.timeout
+        fm_client._fms.timeout = 5
         try:
             # Retry up to 10 times with long backoff between attempts,
             # in order to handle non-`FileMakerError` exceptions such as `RequestException`,
@@ -978,6 +984,10 @@ def _process_record(
             )
             # Return 0 here to show that no changes were made
             return 0
+        # Restore original timeout
+        finally:
+            # Go back to original long timeout for record retrieval
+            fm_client._fms.timeout = old_timeout
 
         # fm_client.edit_record will return False if the update fails without raising an exception,
         # so log that as well and return 0 to show that no changes were made


### PR DESCRIPTION
Implements [DLSR-323](https://uclalibrary.atlassian.net/browse/DLSR-323).

This PR makes 2 small improvements to `filemaker_batch_update.py`:
* Adjust Filemaker client timeouts
  * Initial timeout can now be set optionally in each user's config file, under `[filemaker]`, with `timeout=some_value`.
  * The initial timeout in the script defaults to 120 seconds if the user does not override via config.
  * When updating records, the timeout is reduced to 5 seconds (hard-coded) for each update, then immediately reset to the longer default.
* Allow starting the program at a specific offset / position within the record set.  By default this is 1.
  * Note that this is *not* `record_id`, but the position within the overall list of (all) records being retrieved.

I found that almost all timeouts happened when trying to update a record.  The script was waiting for up to 4 minutes (240 seconds, originally), the timeout would end, and the script would resume.  Reducing the timeout when trying an update allows the script to recover & resume much more quickly almost always.

The timeout problem itself may have many contributing factors: local network / machine, Filemaker server, resource leaks (API client and/or the server itself), record locking.... The script did tend to get slower, with more timeouts, as it progressed through large numbers of updates, so I suspect resource leak(s) somewhere, but did not see anything obvious in our script or a brief look at the `fmrest` package.

No new tests for these changes, but try a dry run using an offset very close to the end.  Currently, this is what I got with an offset of `598920`, which is just below the current total of `598924`:
```
docker compose run ftva_data python filemaker_batch_update.py -c prod_config_secrets.toml -f release_broadcast_year record_date --dry_run --offset 598920

DRY RUN: no changes will be written to Filemaker.
Fields to process: ['release_broadcast_year', 'record_date']
Connected to Filemaker.
Retrieving records in pages of 5000...
Retrieved records 598920 to 598924...
Pagination complete. All records retrieved.
Processing complete. Processed 5 Filemaker record(s). Would update 0 record(s) with 0 total field change(s).
```

The log should show a starting `record_id=796051`.

@henry-r18 FYI.



[DLSR-323]: https://uclalibrary.atlassian.net/browse/DLSR-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ