### PR TITLE
DLSR-329: FM rules validation report

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ Examples below assume you're running them in an existing `bash` shell within the
 a container, add `docker compose exec ftva_data ` to the beginning of the command (e.g., 
 `docker compose exec ftva_data python filemaker_get_all_records.py --config_file CONFIG_FILE` ).
 
+### Report Filemaker validation rule violations
+
+```
+python filemaker_validation_report.py \
+    --config_file CONFIG_FILE \
+    [--start_date MM/DD/YYYY --end_date MM/DD/YYYY] \
+    [--output_csv OUTPUT_FILE]
+```
+
+This script checks records in the FTVA processing database against the "Validation Rules (Analog and Digital)" and reports any violations to a CSV file. Each row in the output represents one violation, identified by FileMaker record ID and inventory ID, with the field name, raw value, and a description of the rule that was broken.
+By default the script iterates all records in the database (slow; expect 20-30 minutes for ~607,000 records). To target only recently added or edited records, pass --start_date and --end_date together; the script will use FileMaker's find API to query only records whose date_modified field falls within that range, which is much faster. Note that very wide date windows (e.g., a full year) may time out.
+Output is written to reports/validation_report_{DATE}_{TIME}.csv by default, or to the path provided via --output_csv. The reports/ directory is created automatically if it does not exist. The script also writes a log file to logs/.
+
+Arguments:
+
+- --config_file (required): path to the TOML config file (see Secrets above).
+- --start_date / --end_date: date range filter on date_modified, in MM/DD/YYYY format. Both must be provided together, or neither.
+- --output_csv: path for the CSV output file.
+
 ### Retrieve all Filemaker records
 
 ```python filemaker_get_all_records.py --config_file CONFIG_FILE```

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ where `LAYOUT` is one of:
 | `NEW DIGITAL_API` | NDM Digital Carrier |
 | `NEW DIGITAL STORAGE_API` | NDM Digital Storage Format |
 
-This script checks records in the specified FileMaker layout against the validation rules defined by FTVA staff and writes any violations to a CSV file. Each row in the output represents one violation, identified by FileMaker record ID, inventory ID, and inventory number, along with the field name, a description of the rule that was broken, and the modification user and timestamp so violations can be traced to recent edits. For violations found inside a FileMaker portal (currently `portal_Portal_DM_Items` on the NDM Digital Carrier layout), a `portal_record_id` column identifies the specific portal row.
+This script checks records in the specified FileMaker layout against the validation rules defined by FTVA staff and writes any violations to a CSV file. Each row in the output represents one violation, identified by FileMaker inventory ID and inventory number, along with the field name, a description of the rule that was broken, and the modification user and timestamp so violations can be traced to recent edits.
 
 By default the script iterates all records in the layout. To target only recently added or edited records, pass `--start_date` and `--end_date` together; the script will use FileMaker's find API to query only records modified within that date range, which is much faster. 
 
@@ -113,10 +113,6 @@ Output is written to `reports/validation_report_{LAYOUT}_{DATE}_{TIME}.csv` by d
 - `--page_size`: number of records to fetch per API request (default: 5000).
 - `--offset`: starting record position for a full scan; ignored when a date range is given (default: 1).
 - `--output_csv`: path for the CSV output file.
-
-**Notes on specific layouts:**
-- The NDM Digital Carrier layout (`NEW DIGITAL_API`) validates both flat record fields and fields inside the `portal_Portal_DM_Items` portal (`Item_unit_number`, `file_size_display`, `Creation_date`, `audio_class`, `file_path`). 
-- The NDM Digital Storage Format layout (`NEW DIGITAL STORAGE_API`) validates `file_path` and `file_size` from the `portal_pDMUnit` portal, in addition to its flat fields.
 
 ### Retrieve all Filemaker records
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ ftva_holdings_report =  "/shared/University of California Los Angeles (UCLA) 01U
 [filemaker]
 api_version="vLatest"
 database="Inventory for Labeling"
-layout="InventoryForLabeling_ReadOnly_API"
+layout="InventoryForLabeling_API"
 password="YOUR_PASSWORD"
 url = "https://adam.cinema.ucla.edu"
 user="YOUR_NAME"
@@ -85,19 +85,38 @@ a container, add `docker compose exec ftva_data ` to the beginning of the comman
 ```
 python filemaker_validation_report.py \
     --config_file CONFIG_FILE \
+    --layout LAYOUT \
     [--start_date MM/DD/YYYY --end_date MM/DD/YYYY] \
+    [--page_size PAGE_SIZE] \
+    [--offset OFFSET] \
     [--output_csv OUTPUT_FILE]
 ```
 
-This script checks records in the FTVA processing database against the "Validation Rules (Analog and Digital)" and reports any violations to a CSV file. Each row in the output represents one violation, identified by FileMaker record ID and inventory ID, with the field name, raw value, and a description of the rule that was broken.
-By default the script iterates all records in the database (slow; expect 20-30 minutes for ~607,000 records). To target only recently added or edited records, pass --start_date and --end_date together; the script will use FileMaker's find API to query only records whose date_modified field falls within that range, which is much faster. Note that very wide date windows (e.g., a full year) may time out.
-Output is written to reports/validation_report_{DATE}_{TIME}.csv by default, or to the path provided via --output_csv. The reports/ directory is created automatically if it does not exist. The script also writes a log file to logs/.
+where `LAYOUT` is one of:
 
-Arguments:
+| Value | FileMaker layout |
+|---|---|
+| `InventoryForLabeling_API` | Analog GE Form |
+| `NEW DIGITAL_API` | NDM Digital Carrier |
+| `NEW DIGITAL STORAGE_API` | NDM Digital Storage Format |
 
-- --config_file (required): path to the TOML config file (see Secrets above).
-- --start_date / --end_date: date range filter on date_modified, in MM/DD/YYYY format. Both must be provided together, or neither.
-- --output_csv: path for the CSV output file.
+This script checks records in the specified FileMaker layout against the validation rules defined by FTVA staff and writes any violations to a CSV file. Each row in the output represents one violation, identified by FileMaker record ID, inventory ID, and inventory number, along with the field name, a description of the rule that was broken, and the modification user and timestamp so violations can be traced to recent edits. For violations found inside a FileMaker portal (currently `portal_Portal_DM_Items` on the NDM Digital Carrier layout), a `portal_record_id` column identifies the specific portal row.
+
+By default the script iterates all records in the layout. To target only recently added or edited records, pass `--start_date` and `--end_date` together; the script will use FileMaker's find API to query only records modified within that date range, which is much faster. 
+
+Output is written to `reports/validation_report_{LAYOUT}_{DATE}_{TIME}.csv` by default, or to the path provided via `--output_csv`. The `reports/` directory is created automatically if it does not exist. A log file is also written to `logs/`.
+
+**Arguments:**
+- `--config_file` (required): path to the TOML config file (see *Secrets* above).
+- `--layout` (required): the FileMaker layout to validate; see table above.
+- `--start_date` / `--end_date`: date range filter, in `MM/DD/YYYY` format. Both must be provided together, or neither.
+- `--page_size`: number of records to fetch per API request (default: 5000).
+- `--offset`: starting record position for a full scan; ignored when a date range is given (default: 1).
+- `--output_csv`: path for the CSV output file.
+
+**Notes on specific layouts:**
+- The NDM Digital Carrier layout (`NEW DIGITAL_API`) validates both flat record fields and fields inside the `portal_Portal_DM_Items` portal (`Item_unit_number`, `file_size_display`, `Creation_date`, `audio_class`, `file_path`). 
+- The NDM Digital Storage Format layout (`NEW DIGITAL STORAGE_API`) validates `file_path` and `file_size` from the `portal_pDMUnit` portal, in addition to its flat fields.
 
 ### Retrieve all Filemaker records
 

--- a/filemaker_utils.py
+++ b/filemaker_utils.py
@@ -7,10 +7,6 @@ from ftva_etl import FilemakerClient
 from fmrest.exceptions import FileMakerError
 from fmrest.record import Record
 
-# --------------------
-# Logging
-# --------------------
-
 
 def configure_logging(logger: logging.Logger, suffix: str = "") -> None:
     """Configure file + console handlers on *logger*.
@@ -43,11 +39,6 @@ def configure_logging(logger: logging.Logger, suffix: str = "") -> None:
     logger.addHandler(console_handler)
 
 
-# --------------------
-# Configuration
-# --------------------
-
-
 def get_config(config_file_name: str) -> dict:
     """Load and return configuration from a TOML file.
 
@@ -58,16 +49,18 @@ def get_config(config_file_name: str) -> dict:
         return tomllib.load(f)
 
 
-# --------------------
-# Filemaker client
-# --------------------
-
-
-def initialize_client(config: dict, logger: logging.Logger) -> FilemakerClient:
+def initialize_client(
+    config: dict,
+    logger: logging.Logger,
+    layout: str | None = None,
+) -> FilemakerClient:
     """Initialize and return a configured Filemaker client.
 
     :param config: Program configuration dict loaded from TOML.
     :param logger: Logger for status/error messages.
+    :param layout: FM layout name to connect to.  If provided, overrides the
+        ``layout`` key in the config file.  Use this when a script needs to
+        connect to multiple layouts in one run.
     :return: An initialized ``FilemakerClient`` instance.
     :raises FileMakerError: If the connection to Filemaker fails.
     """
@@ -81,9 +74,12 @@ def initialize_client(config: dict, logger: logging.Logger) -> FilemakerClient:
     for key in ("url", "database", "layout", "api_version", "timeout"):
         if key in fm_config:
             kwargs[key] = fm_config[key]
+    # Explicit layout argument takes precedence over config file.
+    if layout is not None:
+        kwargs["layout"] = layout
     try:
         client = FilemakerClient(**kwargs)
-        logger.info("Connected to Filemaker.")
+        logger.info(f"Connected to Filemaker layout {kwargs.get('layout')!r}.")
         return client
     except FileMakerError as e:
         logger.error(f"Failed to connect to Filemaker: {e}")
@@ -109,8 +105,6 @@ def get_all_records(
     :param logger: Optional logger for progress messages.
     :return: List of all fmrest ``Record`` objects.
     """
-
-    # Use the provided logger or create a default one for this module
     _log = logger or logging.getLogger(__name__)
     _log.info(f"Retrieving all records in pages of {page_size}...")
 
@@ -133,23 +127,3 @@ def get_all_records(
         current_offset += page_size
 
     return all_records
-
-
-def validate_fields(
-    field_names: list[str],
-    fm_record: Record,
-) -> None:
-    """Verify that every requested field name exists on the given Filemaker record.
-
-    :param field_names: Target field names to validate.
-    :param fm_record: A representative Filemaker record to check field names against.
-    :raises ValueError: If one or more field names are not present on the record.
-    """
-    fm_fields = fm_record.keys()
-    bad_fields = [name for name in field_names if name not in fm_fields]
-    if bad_fields:
-        raise ValueError(
-            f"The following field(s) were not found in Filemaker: "
-            f"{bad_fields}. "
-            f"Available fields are: {sorted(fm_fields)}"
-        )

--- a/filemaker_utils.py
+++ b/filemaker_utils.py
@@ -1,0 +1,155 @@
+import logging
+import tomllib
+from datetime import datetime
+from pathlib import Path
+
+from ftva_etl import FilemakerClient
+from fmrest.exceptions import FileMakerError
+from fmrest.record import Record
+
+# --------------------
+# Logging
+# --------------------
+
+
+def configure_logging(logger: logging.Logger, suffix: str = "") -> None:
+    """Configure file + console handlers on *logger*.
+
+    :param logger: The module-level logger to configure.
+    :param suffix: Optional suffix appended to the log file name
+                   (e.g. ``"_DRY_RUN"``).
+    """
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    logs_dir = Path("logs")
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = logs_dir / f"{logger.name}_{timestamp}{suffix}.log"
+
+    file_formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
+    console_formatter = logging.Formatter("%(message)s")
+
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(file_formatter)
+    file_handler.setLevel(logging.DEBUG)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(console_formatter)
+    console_handler.setLevel(logging.INFO)
+
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
+
+
+# --------------------
+# Configuration
+# --------------------
+
+
+def get_config(config_file_name: str) -> dict:
+    """Load and return configuration from a TOML file.
+
+    :param config_file_name: Path to the TOML configuration file.
+    :return: Configuration dict.
+    """
+    with open(config_file_name, "rb") as f:
+        return tomllib.load(f)
+
+
+# --------------------
+# Filemaker client
+# --------------------
+
+
+def initialize_client(config: dict, logger: logging.Logger) -> FilemakerClient:
+    """Initialize and return a configured Filemaker client.
+
+    :param config: Program configuration dict loaded from TOML.
+    :param logger: Logger for status/error messages.
+    :return: An initialized ``FilemakerClient`` instance.
+    :raises FileMakerError: If the connection to Filemaker fails.
+    """
+    fm_config = config.get("filemaker", {})
+    # Build kwargs from config, only passing keys that are present,
+    # so FilemakerClient's own defaults apply for anything not in the file.
+    kwargs: dict = {
+        "user": fm_config.get("user", ""),
+        "password": fm_config.get("password", ""),
+    }
+    for key in ("url", "database", "layout", "api_version", "timeout"):
+        if key in fm_config:
+            kwargs[key] = fm_config[key]
+    try:
+        client = FilemakerClient(**kwargs)
+        logger.info("Connected to Filemaker.")
+        return client
+    except FileMakerError as e:
+        logger.error(f"Failed to connect to Filemaker: {e}")
+        raise
+
+
+# --------------------
+# Record retrieval
+# --------------------
+
+
+def get_all_records(
+    fm_client: FilemakerClient,
+    page_size: int,
+    offset: int = 1,
+    logger: logging.Logger | None = None,
+) -> list[Record]:
+    """Retrieve every record in the Filemaker database, paginating automatically.
+
+    :param fm_client: A configured FilemakerClient instance.
+    :param page_size: Number of records to retrieve at a time.
+    :param offset: Position (NOT record_id) to start at. Default: 1.
+    :param logger: Optional logger for progress messages.
+    :return: List of all fmrest ``Record`` objects.
+    """
+
+    # Use the provided logger or create a default one for this module
+    _log = logger or logging.getLogger(__name__)
+    _log.info(f"Retrieving all records in pages of {page_size}...")
+
+    all_records = []
+    current_offset = offset
+
+    while True:
+        batch = fm_client.get_records(offset=current_offset, limit=page_size)
+        if not batch:
+            _log.info("Pagination complete. All records retrieved.")
+            break
+        _log.info(
+            f"Retrieved records {current_offset} to "
+            f"{current_offset + len(batch) - 1}..."
+        )
+        all_records.extend(batch)
+        if len(batch) < page_size:
+            _log.info("Pagination complete. All records retrieved.")
+            break
+        current_offset += page_size
+
+    return all_records
+
+
+def validate_fields(
+    field_names: list[str],
+    fm_record: Record,
+) -> None:
+    """Verify that every requested field name exists on the given Filemaker record.
+
+    :param field_names: Target field names to validate.
+    :param fm_record: A representative Filemaker record to check field names against.
+    :raises ValueError: If one or more field names are not present on the record.
+    """
+    fm_fields = fm_record.keys()
+    bad_fields = [name for name in field_names if name not in fm_fields]
+    if bad_fields:
+        raise ValueError(
+            f"The following field(s) were not found in Filemaker: "
+            f"{bad_fields}. "
+            f"Available fields are: {sorted(fm_fields)}"
+        )

--- a/filemaker_validation_report.py
+++ b/filemaker_validation_report.py
@@ -177,7 +177,6 @@ LAYOUT_VALIDATORS: dict[str, dict[str, list[Callable]]] = {
         # file_path and file_size are in portal_pDMUnit; see PORTAL_FIELD_VALIDATORS.
         "Barcode": [_check_null],
         "Location": [_check_null],
-        "storage_format": [_check_null],
     },
 }
 

--- a/filemaker_validation_report.py
+++ b/filemaker_validation_report.py
@@ -1,0 +1,482 @@
+import argparse
+import csv
+import logging
+import re
+import sys
+from collections.abc import (
+    Callable,
+)  # For type hinting single-field validator callables
+from datetime import datetime
+from pathlib import Path
+
+from fmrest.record import Record
+
+import filemaker_utils as fm_utils
+
+# ---------------------------------------------------------------------------
+# Module-level logger
+# ---------------------------------------------------------------------------
+logger = logging.getLogger(Path(__file__).stem)
+
+# Output columns, matching the spec's required fields plus record_id for
+# debugging convenience.
+REPORT_FIELDNAMES = [
+    "record_id",
+    "inventory_id",
+    "inventory_no",
+    "user_last_modified",
+    "date_modified",
+    "field",
+    "violation",
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_null(value: str) -> bool:
+    """Return True if *value* is empty or whitespace-only."""
+    return not value or not value.strip()
+
+
+def _field(record: Record, name: str) -> str:
+    """Return a field value from *record* as a stripped string, or '' if absent."""
+    try:
+        return str(record[name] or "").strip()
+    except (KeyError, AttributeError):
+        return ""
+
+
+def _make_violation(record: Record, field: str, message: str) -> dict:
+    """Build a violation dict in the spec's output format."""
+    return {
+        "record_id": record.record_id,
+        "inventory_id": _field(record, "inventory_id"),
+        "inventory_no": _field(record, "inventory_no"),
+        "user_last_modified": _field(record, "user_last_modified"),
+        "date_modified": _field(record, "date_modified"),
+        "field": field,
+        "violation": message,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Single-field validators
+# Each callable takes a string value and returns a list of error messages.
+# ---------------------------------------------------------------------------
+
+
+def _check_null(value: str) -> list[str]:
+    """Field must not be null / empty."""
+    if _is_null(value):
+        return ["Field is null or empty."]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Field -> validator mapping
+# ---------------------------------------------------------------------------
+# Organised by layout, matching the spec table.  Each entry maps a FM field
+# name to an ordered list of single-field validator callables.
+#
+# Layout abbreviations used in comments:
+#   GE  = Analog GE Form
+#   DC  = NDM Digital Carrier Layout
+#   DS  = NDM Digital Storage Format Layout
+
+FIELD_VALIDATORS: dict[str, list[Callable[[str], list[str]]]] = {
+    # ---- Fields present on GE and DC layouts ----
+    "production_type": [
+        _check_null
+    ],  # GE, DC  (cross-field rule also applies; see below)
+    "Language": [_check_null],  # GE, DC
+    "donor_code": [_check_null],  # GE, DC
+    "Acquisition type": [_check_null],  # GE, DC
+    "type": [_check_null],  # GE, DC
+    "item_unit_holdings": [_check_null],  # GE, DC
+    "title": [_check_null],  # GE, DC
+    "date_received": [_check_null],  # GE, DC
+    "director": [_check_null],  # GE, DC
+    "release_broadcast_year": [
+        _check_null
+    ],  # GE, DC  (cross-field rule also applies; see below)
+    # ---- Fields present on DC layout only ----
+    # TODO: Enable once NDM Digital Carrier layout is available via API.
+    # "Item_unit_number":   [_check_null],  # DC only
+    # "file_size":          [_check_null],  # DC only
+    # "Creation_date":      [_check_null],  # DC only
+    # "audio_class":        [_check_null],  # DC only
+    # "retention_status":   [_check_null],  # DC only  (cross-field rule also applies; see below)
+    # "asset_type":         [_check_null],  # DC only
+    # "sound_format":       [_check_null],  # DC only  (conditional; see _check_cross_field_rules)
+    # ---- Fields present on DS layout only ----
+    # TODO: Enable once NDM Digital Storage Format layout is available via API.
+    # "file_path":          [_check_null],  # DC and DS
+    # "Barcode":            [_check_null],  # DS only
+    # "Location":           [_check_null],  # DS only
+    # ---- Fields present on GE layout only ----
+    "format": [_check_null],  # GE only
+    "inventory_no": [_check_null],  # GE only
+}
+
+
+# ---------------------------------------------------------------------------
+# Cross-field / conditional rules
+# ---------------------------------------------------------------------------
+
+
+def _check_cross_field_rules(record: Record) -> list[dict]:
+    """Check rules that depend on the value of more than one field.
+
+    Implements the following rules from the spec:
+
+    1. Where production_type = "TELEVISION SERIES", flag if episode_no or
+       episode_title are null.
+    2. Where release_broadcast_year = "N/A" or "Unknown", flag if record_date
+       is null.
+    3. (TODO - DC layout) Where retention_status = "Temporary", flag if
+       retention_start_date or retention_end_date are null.
+    4. (TODO - DC layout) Where object_purpose = "Preservation (Full)" or
+       "Access (Core)", flag if sound_format is null.
+
+    :param record: A fmrest Record object.
+    :return: List of violation dicts.
+    """
+    violations = []
+
+    # Rule 1: TELEVISION SERIES requires episode fields
+    production_type = _field(record, "production_type")
+    if production_type.upper() == "TELEVISION SERIES":
+        if _is_null(_field(record, "episode no.")):
+            violations.append(
+                _make_violation(
+                    record,
+                    "episode no.",
+                    "episode no. is null but production_type is 'TELEVISION SERIES'.",
+                )
+            )
+        if _is_null(_field(record, "episode_title")):
+            violations.append(
+                _make_violation(
+                    record,
+                    "episode_title",
+                    "episode_title is null but production_type is 'TELEVISION SERIES'.",
+                )
+            )
+
+    # Rule 2: N/A or Unknown release_broadcast_year requires record_date
+    release_year = _field(record, "release_broadcast_year")
+    if release_year.upper() in ("N/A", "UNKNOWN"):
+        if _is_null(_field(record, "record_date")):
+            violations.append(
+                _make_violation(
+                    record,
+                    "record_date",
+                    f"record_date is null but release_broadcast_year is {release_year!r}.",
+                )
+            )
+
+    # Rule 3: (TODO - DC layout) Temporary retention requires date range
+    # retention_status = _field(record, "retention_status")
+    # if retention_status.upper() == "TEMPORARY":
+    #     if _is_null(_field(record, "retention_start_date")):
+    #         violations.append(_make_violation(
+    #             record, "retention_start_date",
+    #             "retention_start_date is null but retention_status is 'Temporary'."
+    #         ))
+    #     if _is_null(_field(record, "retention_end_date")):
+    #         violations.append(_make_violation(
+    #             record, "retention_end_date",
+    #             "retention_end_date is null but retention_status is 'Temporary'."
+    #         ))
+
+    # Rule 4: (TODO - DC layout) Preservation/access records require sound_format
+    # OBJECT_PURPOSES_REQUIRING_SOUND_FORMAT = {
+    #     "PRESERVATION (FULL)", "ACCESS (CORE)"
+    # }
+    # object_purpose = _field(record, "object_purpose")
+    # if object_purpose.upper() in OBJECT_PURPOSES_REQUIRING_SOUND_FORMAT:
+    #     if _is_null(_field(record, "sound_format(1)")):
+    #         violations.append(_make_violation(
+    #             record, "sound_format(1)",
+    #             f"sound_format is null but object_purpose is {object_purpose!r}."
+    #         ))
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Notes field check (stretch goal per spec)
+# ---------------------------------------------------------------------------
+
+# Valid section headers as defined in the spec.
+_NOTES_HEADERS = {
+    "General Notes",
+    "Language Notes",
+    "Credits",
+    "Credits Notes",
+    "Dates Notes",
+    "Titles Notes",
+}
+
+# Pattern for a correctly formatted notes section:
+# "Header: <non-empty text><carriage return>"
+# We check each header found in the field value.
+_NOTES_HEADER_PATTERN = re.compile(
+    r"^(?P<header>.+?):\s+(?P<body>.+?)(?:\r|$)",
+    re.MULTILINE,
+)
+
+
+def _check_notes_field(record: Record) -> list[dict]:
+    """Check the notes field for correct section header formatting.
+
+    The spec requires that any of the recognised headers (e.g. "Language
+    Notes", "Credits Notes") must be followed by a colon, a space, body text,
+    and a carriage return.  Violations are reported if:
+      - A recognised header is present but not followed by ": <text><CR>".
+      - A header-like token (word(s) followed by colon) is present that is
+        not in the recognised header list, which may indicate a typo.
+
+    This check is marked as a stretch goal in the spec; disable it by removing
+    "notes" from FIELD_VALIDATORS if the false-positive rate is too high.
+
+    :param record: A fmrest Record object.
+    :return: List of violation dicts (may be empty).
+    """
+    value = _field(record, "notes")
+    if _is_null(value):
+        return []
+
+    violations = []
+
+    for header in _NOTES_HEADERS:
+        # Check if this header appears in the field at all
+        if header not in value:
+            continue
+
+        # It's present: verify it's formatted as "Header: <text><CR>"
+        pattern = re.compile(
+            rf"^{re.escape(header)}:\s+\S.*?(?:\r|$)",
+            re.MULTILINE,
+        )
+        if not pattern.search(value):
+            violations.append(
+                _make_violation(
+                    record,
+                    "notes",
+                    f"Header {header!r} is present but not correctly formatted. "
+                    f"Expected: '{header}: <text><CR>'.",
+                )
+            )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Per-record validation entry point
+# ---------------------------------------------------------------------------
+
+
+def validate_record(record: Record) -> list[dict]:
+    """Run all validation checks against *record* and return violations.
+
+    Runs:
+      1. Single-field null checks from FIELD_VALIDATORS.
+      2. Cross-field conditional rules from _check_cross_field_rules().
+      3. Notes field formatting check from _check_notes_field().
+
+    :param record: A fmrest Record object.
+    :return: List of violation dicts with keys matching REPORT_FIELDNAMES.
+    """
+    record_dict = record.to_dict()
+    violations = []
+
+    # 1. Single-field checks
+    for field_name, validators in FIELD_VALIDATORS.items():
+        if field_name not in record_dict:
+            logger.debug(
+                f"Field {field_name!r} not on record {record.record_id}; skipping."
+            )
+            continue
+        value = str(record[field_name] or "")
+        for validator in validators:
+            for message in validator(value):
+                v = _make_violation(record, field_name, message)
+                violations.append(v)
+                logger.debug(
+                    f"VIOLATION record_id={record.record_id} "
+                    f"inventory_id={v['inventory_id']!r} "
+                    f"field={field_name!r}: {message}"
+                )
+
+    # 2. Cross-field rules
+    for v in _check_cross_field_rules(record):
+        violations.append(v)
+        logger.debug(
+            f"VIOLATION (cross-field) record_id={record.record_id} "
+            f"inventory_id={v['inventory_id']!r} "
+            f"field={v['field']!r}: {v['violation']}"
+        )
+
+    # 3. Notes field
+    for v in _check_notes_field(record):
+        violations.append(v)
+        logger.debug(
+            f"VIOLATION (notes) record_id={record.record_id} "
+            f"inventory_id={v['inventory_id']!r}: {v['violation']}"
+        )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Report output
+# ---------------------------------------------------------------------------
+
+
+def _write_csv_report(violations: list[dict], output_path: Path) -> None:
+    """Write *violations* to a CSV file at *output_path*.
+
+    :param violations: List of violation dicts from validate_record().
+    :param output_path: Destination path; parent directories are created if needed.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=REPORT_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(violations)
+    logger.info(f"Report written to {output_path} ({len(violations)} violation(s)).")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _get_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Report violations of FileMaker validation rules "
+            "(Analog and Digital) for FTVA MAMS records."
+        )
+    )
+    parser.add_argument(
+        "-c",
+        "--config_file",
+        type=str,
+        required=True,
+        help="Path to TOML configuration file containing Filemaker API credentials.",
+    )
+    parser.add_argument(
+        "--page_size",
+        type=int,
+        default=5000,
+        required=False,
+        help=(
+            "Number of records to fetch per request to Filemaker. " "Default is 5000."
+        ),
+    )
+    parser.add_argument(
+        "--offset",
+        type=int,
+        default=1,
+        required=False,
+        help=(
+            "Offset (position in list of records, NOT `record_id`) to start "
+            "fetching records from Filemaker. Only applies when no date range "
+            "is given. Default is 1."
+        ),
+    )
+    parser.add_argument(
+        "--start_date",
+        type=str,
+        default=None,
+        metavar="MM/DD/YYYY",
+        help=(
+            "If provided, only validate records whose `date_modified` field is "
+            "on or after this date. Requires --end_date."
+        ),
+    )
+    parser.add_argument(
+        "--end_date",
+        type=str,
+        default=None,
+        metavar="MM/DD/YYYY",
+        help=(
+            "If provided, only validate records whose `date_modified` field is "
+            "on or before this date. Requires --start_date."
+        ),
+    )
+    parser.add_argument(
+        "--output_csv",
+        type=str,
+        default=None,
+        help=(
+            "Path to write the CSV violation report. "
+            "Defaults to reports/validation_report_YYYYMMDD_HHMMSS.csv."
+        ),
+    )
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    args = _get_arguments()
+
+    fm_utils.configure_logging(logger)
+
+    if bool(args.start_date) != bool(args.end_date):
+        logger.error("--start_date and --end_date must both be provided, or neither.")
+        sys.exit(1)
+
+    config = fm_utils.get_config(args.config_file)
+    fm_client = fm_utils.initialize_client(config, logger)
+
+    if args.output_csv:
+        output_path = Path(args.output_csv)
+    else:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_path = Path("reports") / f"validation_report_{timestamp}.csv"
+
+    # ---- Fetch records ----
+    if args.start_date and args.end_date:
+        logger.info(
+            f"Fetching records modified between {args.start_date} and {args.end_date}."
+        )
+        records = fm_client.find_all_records(
+            query=[{"date_modified": f"{args.start_date}...{args.end_date}"}],
+            page_size=args.page_size,
+        )
+        logger.info(f"Found {len(records)} record(s) in date range.")
+    else:
+        logger.info("No date range supplied; retrieving all records.")
+        records = fm_utils.get_all_records(
+            fm_client=fm_client,
+            page_size=args.page_size,
+            offset=args.offset,
+            logger=logger,
+        )
+
+    # ---- Validate ----
+    all_violations: list[dict] = []
+    for record in records:
+        all_violations.extend(validate_record(record))
+
+    logger.info(
+        f"Processed {len(records)} record(s); "
+        f"found {len(all_violations)} violation(s)."
+    )
+
+    # ---- Report ----
+    _write_csv_report(all_violations, output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/filemaker_validation_report.py
+++ b/filemaker_validation_report.py
@@ -52,17 +52,17 @@ LAYOUT_METADATA: dict[str, dict[str, str]] = {
     },
 }
 
-# Portal name on the NEW DIGITAL_API layout that contains the DC-only fields.
-PORTAL_DM_ITEMS = "portal_Portal_DM_Items"
+# Portal name on NEW DIGITAL_API (DC layout) that contains Digital Media fields (item-level data).
+DC_PORTAL = "portal_Portal_DM_Items"
 
-# Table occurrence prefix used by FM for fields in the DM Items portal.
-DM_PREFIX = "Digital Media_Item Unit::"
+# For NEW DIGITAL_API (DC layout), fields in the portal are accessed using this prefix.
+DC_PORTAL_PREFIX = "Digital Media_Item Unit::"
 
-# Portal name on the NEW DIGITAL STORAGE_API layout containing file path/size.
-PORTAL_DM_UNIT = "portal_pDMUnit"
+# Portal name on NEW DIGITAL STORAGE_API (DS layout) that contains carrier fields (file path/size).
+DS_PORTAL = "portal_pDMUnit"
 
-# Table occurrence prefix used by FM for fields in the DS portal.
-DM_CARRIER_PREFIX = "Digital Media_carrier::"
+# For NEW DIGITAL STORAGE_API (DS layout), fields in the portal are accessed using this prefix.
+DS_PORTAL_PREFIX = "Digital Media_carrier::"
 
 
 # ---------------------------------------------------------------------------
@@ -135,6 +135,8 @@ def _check_null(value: str) -> list[str]:
 # Layout -> flat field -> validators mapping
 # ---------------------------------------------------------------------------
 # Fields that live directly on the record (not in portals).
+# For now, each field has only a single validator (_check_null),
+# but using a list for each field allows us to add more if needed.
 
 LAYOUT_VALIDATORS: dict[str, dict[str, list[Callable]]] = {
     # Analog GE Form layout
@@ -187,14 +189,14 @@ LAYOUT_VALIDATORS: dict[str, dict[str, list[Callable]]] = {
 # Fields that live inside FileMaker portals.
 
 PORTAL_FIELD_VALIDATORS: dict[str, dict[str, list[Callable]]] = {
-    PORTAL_DM_ITEMS: {
+    DC_PORTAL: {
         "Item_unit_number": [_check_null],
         "file_size_display": [_check_null],
         "Creation_date": [_check_null],
         "audio_class": [_check_null],
         "file_path": [_check_null],
     },
-    PORTAL_DM_UNIT: {
+    DS_PORTAL: {
         "file_path": [_check_null],
         "file_size": [_check_null],
     },
@@ -203,8 +205,8 @@ PORTAL_FIELD_VALIDATORS: dict[str, dict[str, list[Callable]]] = {
 # Which layouts have which portals, and the prefix for each portal's fields.
 # Used by _check_portal_fields() to iterate and access portal rows.
 LAYOUT_PORTALS: dict[str, list[tuple[str, str]]] = {
-    "NEW DIGITAL_API": [(PORTAL_DM_ITEMS, DM_PREFIX)],
-    "NEW DIGITAL STORAGE_API": [(PORTAL_DM_UNIT, DM_CARRIER_PREFIX)],
+    "NEW DIGITAL_API": [(DC_PORTAL, DC_PORTAL_PREFIX)],
+    "NEW DIGITAL STORAGE_API": [(DS_PORTAL, DS_PORTAL_PREFIX)],
 }
 
 
@@ -327,7 +329,7 @@ def _check_cross_field_rules(layout: str, record: Record) -> list[dict]:
                     )
 
         # Rule 4: Preservation/access records require sound_format.
-        OBJECT_PURPOSES_REQUIRING_SOUND = {"PRESERVATION (FULL)", "ACCESS (CORE)"}
+        OBJECT_PURPOSES_REQUIRING_SOUND = ["PRESERVATION (FULL)", "ACCESS (CORE)"]
         object_purpose = _get_field(record, "object_purpose")
         if object_purpose.upper() in OBJECT_PURPOSES_REQUIRING_SOUND:
             if _is_null(_get_field(record, "sound_format(1)")):

--- a/filemaker_validation_report.py
+++ b/filemaker_validation_report.py
@@ -1,11 +1,8 @@
 import argparse
 import csv
 import logging
-import re
 import sys
-from collections.abc import (
-    Callable,
-)  # For type hinting single-field validator callables
+from collections.abc import Callable  # for type hinting validator functions
 from datetime import datetime
 from pathlib import Path
 
@@ -13,22 +10,59 @@ from fmrest.record import Record
 
 import filemaker_utils as fm_utils
 
-# ---------------------------------------------------------------------------
-# Module-level logger
-# ---------------------------------------------------------------------------
+# Use module-level logger.
 logger = logging.getLogger(Path(__file__).stem)
 
-# Output columns, matching the spec's required fields plus record_id for
-# debugging convenience.
+
+# ---------------------------------------------------------------------------
+# Output and Metadata Constants
+# ---------------------------------------------------------------------------
+
+# Output columns for CSV report.
 REPORT_FIELDNAMES = [
-    "record_id",
     "inventory_id",
     "inventory_no",
+    "field",
     "user_last_modified",
     "date_modified",
-    "field",
     "violation",
 ]
+
+# Per-layout field name differences for the standard output columns.
+# This allows the validation logic to refer to these fields by a consistent name
+# (e.g. "inventory_id", "date_modified") even though the actual field names vary by layout.
+LAYOUT_METADATA: dict[str, dict[str, str]] = {
+    "InventoryForLabeling_API": {
+        "inventory_id_field": "inventory_id",
+        "inventory_no_field": "inventory_no",
+        "user_last_modified_field": "user_last_modified",
+        "date_modified_field": "date_modified",
+    },
+    "NEW DIGITAL_API": {
+        "inventory_id_field": "inventory_id",
+        "inventory_no_field": "inventory_no",
+        "user_last_modified_field": "user_last_modified",
+        "date_modified_field": "date_modified",
+    },
+    "NEW DIGITAL STORAGE_API": {
+        "inventory_id_field": "Inventory_id_fk",
+        "inventory_no_field": "Inventory_no_fk",
+        "user_last_modified_field": "ModifiedBy",
+        "date_modified_field": "ModificationTimestamp",
+    },
+}
+
+# Portal name on the NEW DIGITAL_API layout that contains the DC-only fields.
+PORTAL_DM_ITEMS = "portal_Portal_DM_Items"
+
+# Table occurrence prefix used by FM for fields in the DM Items portal.
+DM_PREFIX = "Digital Media_Item Unit::"
+
+# Portal name on the NEW DIGITAL STORAGE_API layout containing file path/size.
+PORTAL_DM_UNIT = "portal_pDMUnit"
+
+# Table occurrence prefix used by FM for fields in the DS portal.
+DM_CARRIER_PREFIX = "Digital Media_carrier::"
 
 
 # ---------------------------------------------------------------------------
@@ -37,26 +71,49 @@ REPORT_FIELDNAMES = [
 
 
 def _is_null(value: str) -> bool:
-    """Return True if *value* is empty or whitespace-only."""
+    """Return True if value is empty or whitespace-only."""
     return not value or not value.strip()
 
 
-def _field(record: Record, name: str) -> str:
-    """Return a field value from *record* as a stripped string, or '' if absent."""
+def _get_field(record: Record, name: str) -> str:
+    """Return a flat field value from a record as a stripped string, or '' if absent."""
     try:
         return str(record[name] or "").strip()
     except (KeyError, AttributeError):
         return ""
 
 
-def _make_violation(record: Record, field: str, message: str) -> dict:
-    """Build a violation dict in the spec's output format."""
+def _get_portal_field(portal_record: Record, bare_name: str, prefix: str) -> str:
+    """Return a field value from a portal row record.
+
+    FileMaker portal rows store fields as 'TableOccurrence::fieldName'.
+    This helper accepts the bare field name and prepends the prefix.
+    """
+    return _get_field(portal_record, f"{prefix}{bare_name}")
+
+
+def _make_violation(
+    layout: str,
+    record: Record,
+    field: str,
+    message: str,
+    portal_record_id: str = "",
+) -> dict:
+    """Build a violation dict for use in the output report CSV.
+
+    :param layout: FM layout name.
+    :param record: The top-level fmrest Record.
+    :param field: The field name (may include portal prefix for portal fields).
+    :param message: Human-readable description of the violation.
+    """
+    metadata = LAYOUT_METADATA[layout]
     return {
         "record_id": record.record_id,
-        "inventory_id": _field(record, "inventory_id"),
-        "inventory_no": _field(record, "inventory_no"),
-        "user_last_modified": _field(record, "user_last_modified"),
-        "date_modified": _field(record, "date_modified"),
+        "portal_record_id": portal_record_id,
+        "inventory_id": _get_field(record, metadata["inventory_id_field"]),
+        "inventory_no": _get_field(record, metadata["inventory_no_field"]),
+        "user_last_modified": _get_field(record, metadata["user_last_modified_field"]),
+        "date_modified": _get_field(record, metadata["date_modified_field"]),
         "field": field,
         "violation": message,
     }
@@ -64,7 +121,6 @@ def _make_violation(record: Record, field: str, message: str) -> dict:
 
 # ---------------------------------------------------------------------------
 # Single-field validators
-# Each callable takes a string value and returns a list of error messages.
 # ---------------------------------------------------------------------------
 
 
@@ -76,257 +132,271 @@ def _check_null(value: str) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Field -> validator mapping
+# Layout -> flat field -> validators mapping
 # ---------------------------------------------------------------------------
-# Organised by layout, matching the spec table.  Each entry maps a FM field
-# name to an ordered list of single-field validator callables.
-#
-# Layout abbreviations used in comments:
-#   GE  = Analog GE Form
-#   DC  = NDM Digital Carrier Layout
-#   DS  = NDM Digital Storage Format Layout
+# Fields that live directly on the record (not in portals).
 
-FIELD_VALIDATORS: dict[str, list[Callable[[str], list[str]]]] = {
-    # ---- Fields present on GE and DC layouts ----
-    "production_type": [
-        _check_null
-    ],  # GE, DC  (cross-field rule also applies; see below)
-    "Language": [_check_null],  # GE, DC
-    "donor_code": [_check_null],  # GE, DC
-    "Acquisition type": [_check_null],  # GE, DC
-    "type": [_check_null],  # GE, DC
-    "item_unit_holdings": [_check_null],  # GE, DC
-    "title": [_check_null],  # GE, DC
-    "date_received": [_check_null],  # GE, DC
-    "director": [_check_null],  # GE, DC
-    "release_broadcast_year": [
-        _check_null
-    ],  # GE, DC  (cross-field rule also applies; see below)
-    # ---- Fields present on DC layout only ----
-    # TODO: Enable once NDM Digital Carrier layout is available via API.
-    # "Item_unit_number":   [_check_null],  # DC only
-    # "file_size":          [_check_null],  # DC only
-    # "Creation_date":      [_check_null],  # DC only
-    # "audio_class":        [_check_null],  # DC only
-    # "retention_status":   [_check_null],  # DC only  (cross-field rule also applies; see below)
-    # "asset_type":         [_check_null],  # DC only
-    # "sound_format":       [_check_null],  # DC only  (conditional; see _check_cross_field_rules)
-    # ---- Fields present on DS layout only ----
-    # TODO: Enable once NDM Digital Storage Format layout is available via API.
-    # "file_path":          [_check_null],  # DC and DS
-    # "Barcode":            [_check_null],  # DS only
-    # "Location":           [_check_null],  # DS only
-    # ---- Fields present on GE layout only ----
-    "format": [_check_null],  # GE only
-    "inventory_no": [_check_null],  # GE only
+LAYOUT_VALIDATORS: dict[str, dict[str, list[Callable]]] = {
+    # Analog GE Form layout
+    "InventoryForLabeling_API": {
+        "production_type": [_check_null],  # cross-field rule also applies
+        "Language": [_check_null],
+        "donor_code": [_check_null],
+        "Acquisition type": [_check_null],
+        "type": [_check_null],
+        "item_unit_holdings": [_check_null],
+        "title": [_check_null],
+        "date_received": [_check_null],
+        "director": [_check_null],
+        "release_broadcast_year": [_check_null],  # cross-field rule also applies
+        "format": [_check_null],
+        "inventory_no": [_check_null],
+    },
+    # NDM Digital Carrier layout
+    "NEW DIGITAL_API": {
+        # Fields shared with GE layout
+        "production_type": [_check_null],  # cross-field rule also applies
+        "Language": [_check_null],
+        "donor_code": [_check_null],
+        "Acquisition type": [_check_null],
+        "type": [_check_null],
+        "item_unit_holdings": [_check_null],
+        "title": [_check_null],
+        "date_received": [_check_null],
+        "director": [_check_null],
+        "release_broadcast_year": [_check_null],  # cross-field rule also applies
+        # DC-only flat fields
+        "retention_status": [_check_null],  # cross-field rule also applies
+        "asset_type": [_check_null],
+        # sound_format(1): conditional only; see _check_cross_field_rules
+        # Item_unit_number, file_size, Creation_date, audio_class, file_path:
+        #   found in portal_Portal_DM_Items; see PORTAL_FIELD_VALIDATORS below
+    },
+    # NDM Digital Storage Format layout
+    "NEW DIGITAL STORAGE_API": {
+        # file_path and file_size are in portal_pDMUnit; see PORTAL_FIELD_VALIDATORS.
+        "Barcode": [_check_null],
+        "Location": [_check_null],
+        "storage_format": [_check_null],
+    },
 }
 
 
 # ---------------------------------------------------------------------------
-# Cross-field / conditional rules
+# Portal field -> validators mapping
 # ---------------------------------------------------------------------------
+# Fields that live inside FileMaker portals.
 
-
-def _check_cross_field_rules(record: Record) -> list[dict]:
-    """Check rules that depend on the value of more than one field.
-
-    Implements the following rules from the spec:
-
-    1. Where production_type = "TELEVISION SERIES", flag if episode_no or
-       episode_title are null.
-    2. Where release_broadcast_year = "N/A" or "Unknown", flag if record_date
-       is null.
-    3. (TODO - DC layout) Where retention_status = "Temporary", flag if
-       retention_start_date or retention_end_date are null.
-    4. (TODO - DC layout) Where object_purpose = "Preservation (Full)" or
-       "Access (Core)", flag if sound_format is null.
-
-    :param record: A fmrest Record object.
-    :return: List of violation dicts.
-    """
-    violations = []
-
-    # Rule 1: TELEVISION SERIES requires episode fields
-    production_type = _field(record, "production_type")
-    if production_type.upper() == "TELEVISION SERIES":
-        if _is_null(_field(record, "episode no.")):
-            violations.append(
-                _make_violation(
-                    record,
-                    "episode no.",
-                    "episode no. is null but production_type is 'TELEVISION SERIES'.",
-                )
-            )
-        if _is_null(_field(record, "episode_title")):
-            violations.append(
-                _make_violation(
-                    record,
-                    "episode_title",
-                    "episode_title is null but production_type is 'TELEVISION SERIES'.",
-                )
-            )
-
-    # Rule 2: N/A or Unknown release_broadcast_year requires record_date
-    release_year = _field(record, "release_broadcast_year")
-    if release_year.upper() in ("N/A", "UNKNOWN"):
-        if _is_null(_field(record, "record_date")):
-            violations.append(
-                _make_violation(
-                    record,
-                    "record_date",
-                    f"record_date is null but release_broadcast_year is {release_year!r}.",
-                )
-            )
-
-    # Rule 3: (TODO - DC layout) Temporary retention requires date range
-    # retention_status = _field(record, "retention_status")
-    # if retention_status.upper() == "TEMPORARY":
-    #     if _is_null(_field(record, "retention_start_date")):
-    #         violations.append(_make_violation(
-    #             record, "retention_start_date",
-    #             "retention_start_date is null but retention_status is 'Temporary'."
-    #         ))
-    #     if _is_null(_field(record, "retention_end_date")):
-    #         violations.append(_make_violation(
-    #             record, "retention_end_date",
-    #             "retention_end_date is null but retention_status is 'Temporary'."
-    #         ))
-
-    # Rule 4: (TODO - DC layout) Preservation/access records require sound_format
-    # OBJECT_PURPOSES_REQUIRING_SOUND_FORMAT = {
-    #     "PRESERVATION (FULL)", "ACCESS (CORE)"
-    # }
-    # object_purpose = _field(record, "object_purpose")
-    # if object_purpose.upper() in OBJECT_PURPOSES_REQUIRING_SOUND_FORMAT:
-    #     if _is_null(_field(record, "sound_format(1)")):
-    #         violations.append(_make_violation(
-    #             record, "sound_format(1)",
-    #             f"sound_format is null but object_purpose is {object_purpose!r}."
-    #         ))
-
-    return violations
-
-
-# ---------------------------------------------------------------------------
-# Notes field check (stretch goal per spec)
-# ---------------------------------------------------------------------------
-
-# Valid section headers as defined in the spec.
-_NOTES_HEADERS = {
-    "General Notes",
-    "Language Notes",
-    "Credits",
-    "Credits Notes",
-    "Dates Notes",
-    "Titles Notes",
+PORTAL_FIELD_VALIDATORS: dict[str, dict[str, list[Callable]]] = {
+    PORTAL_DM_ITEMS: {
+        "Item_unit_number": [_check_null],
+        "file_size_display": [_check_null],
+        "Creation_date": [_check_null],
+        "audio_class": [_check_null],
+        "file_path": [_check_null],
+    },
+    PORTAL_DM_UNIT: {
+        "file_path": [_check_null],
+        "file_size": [_check_null],
+    },
 }
 
-# Pattern for a correctly formatted notes section:
-# "Header: <non-empty text><carriage return>"
-# We check each header found in the field value.
-_NOTES_HEADER_PATTERN = re.compile(
-    r"^(?P<header>.+?):\s+(?P<body>.+?)(?:\r|$)",
-    re.MULTILINE,
-)
+# Which layouts have which portals, and the prefix for each portal's fields.
+# Used by _check_portal_fields() to iterate and access portal rows.
+LAYOUT_PORTALS: dict[str, list[tuple[str, str]]] = {
+    "NEW DIGITAL_API": [(PORTAL_DM_ITEMS, DM_PREFIX)],
+    "NEW DIGITAL STORAGE_API": [(PORTAL_DM_UNIT, DM_CARRIER_PREFIX)],
+}
 
 
-def _check_notes_field(record: Record) -> list[dict]:
-    """Check the notes field for correct section header formatting.
+# ---------------------------------------------------------------------------
+# Portal field validation
+# ---------------------------------------------------------------------------
 
-    The spec requires that any of the recognised headers (e.g. "Language
-    Notes", "Credits Notes") must be followed by a colon, a space, body text,
-    and a carriage return.  Violations are reported if:
-      - A recognised header is present but not followed by ": <text><CR>".
-      - A header-like token (word(s) followed by colon) is present that is
-        not in the recognised header list, which may indicate a typo.
 
-    This check is marked as a stretch goal in the spec; disable it by removing
-    "notes" from FIELD_VALIDATORS if the false-positive rate is too high.
-
-    :param record: A fmrest Record object.
-    :return: List of violation dicts (may be empty).
-    """
-    value = _field(record, "notes")
-    if _is_null(value):
-        return []
-
+def _check_portal_fields(layout: str, record: Record) -> list[dict]:
+    """Validate fields inside portal rows for the given layout and record."""
     violations = []
+    portals = LAYOUT_PORTALS.get(layout, [])
 
-    for header in _NOTES_HEADERS:
-        # Check if this header appears in the field at all
-        if header not in value:
+    for portal_name, prefix in portals:
+        field_validators = PORTAL_FIELD_VALIDATORS.get(portal_name, {})
+        if not field_validators:
             continue
 
-        # It's present: verify it's formatted as "Header: <text><CR>"
-        pattern = re.compile(
-            rf"^{re.escape(header)}:\s+\S.*?(?:\r|$)",
-            re.MULTILINE,
-        )
-        if not pattern.search(value):
-            violations.append(
-                _make_violation(
-                    record,
-                    "notes",
-                    f"Header {header!r} is present but not correctly formatted. "
-                    f"Expected: '{header}: <text><CR>'.",
-                )
+        portal_foundset = record[portal_name]
+        rows = list(portal_foundset)
+
+        if not rows:
+            logger.debug(
+                f"[{layout}] Portal {portal_name!r} is empty on "
+                f"record_id={record.record_id}; skipping portal checks."
             )
+            continue
+
+        for portal_row in rows:
+            portal_record_id = str(_get_field(portal_row, "recordId"))
+            for bare_name, validators in field_validators.items():
+                value = _get_portal_field(portal_row, bare_name, prefix)
+                for validator in validators:
+                    for message in validator(value):
+                        # Use the bare field name in the field column and include
+                        # the portal row id in the violation dict for logging only.
+                        field_label = bare_name
+                        v = _make_violation(
+                            layout, record, field_label, message, portal_record_id
+                        )
+                        violations.append(v)
 
     return violations
 
 
 # ---------------------------------------------------------------------------
-# Per-record validation entry point
+# Cross-field conditional rules
 # ---------------------------------------------------------------------------
 
 
-def validate_record(record: Record) -> list[dict]:
-    """Run all validation checks against *record* and return violations.
+def _check_cross_field_rules(layout: str, record: Record) -> list[dict]:
+    """Check rules that depend on the value of more than one field.
 
-    Runs:
-      1. Single-field null checks from FIELD_VALIDATORS.
-      2. Cross-field conditional rules from _check_cross_field_rules().
-      3. Notes field formatting check from _check_notes_field().
+    Rules by layout:
 
-    :param record: A fmrest Record object.
-    :return: List of violation dicts with keys matching REPORT_FIELDNAMES.
+    GE and DC layouts:
+      1. Where production_type = "TELEVISION SERIES", flag if episode no. or
+         episode_title are null.
+      2. Where release_broadcast_year = "N/A" or "Unknown", flag if record_date
+         is null.
+
+    DC layout only:
+      3. Where retention_status = "Temporary", flag if retention_start_date or
+         retention_end_date are null.
+      4. Where object_purpose = "Preservation (Full)" or "Access (Core)", flag
+         if sound_format(1) is null.
+
+    DS layout: no cross-field rules currently defined.
     """
-    record_dict = record.to_dict()
     violations = []
 
-    # 1. Single-field checks
-    for field_name, validators in FIELD_VALIDATORS.items():
+    # Rules 1 and 2 apply to both GE and DC layouts.
+    if layout in ("InventoryForLabeling_API", "NEW DIGITAL_API"):
+
+        # Rule 1: TELEVISION SERIES requires episode fields.
+        production_type = _get_field(record, "production_type")
+        if production_type.upper() == "TELEVISION SERIES":
+            for ep_field in ("episode no.", "episode_title"):
+                if _is_null(_get_field(record, ep_field)):
+                    violations.append(
+                        _make_violation(
+                            layout,
+                            record,
+                            ep_field,
+                            f"{ep_field} is null but production_type is "
+                            f"'TELEVISION SERIES'.",
+                        )
+                    )
+
+        # Rule 2: N/A or Unknown release_broadcast_year requires record_date.
+        release_year = _get_field(record, "release_broadcast_year")
+        if release_year.upper() in ("N/A", "UNKNOWN"):
+            if _is_null(_get_field(record, "record_date")):
+                violations.append(
+                    _make_violation(
+                        layout,
+                        record,
+                        "record_date",
+                        f"record_date is null but release_broadcast_year is "
+                        f"{release_year!r}.",
+                    )
+                )
+
+    # Rules 3 and 4 apply to DC layout only.
+    if layout == "NEW DIGITAL_API":
+
+        # Rule 3: Temporary retention requires start and end dates.
+        retention_status = _get_field(record, "retention_status")
+        if retention_status.upper() == "TEMPORARY":
+            for date_field in ("retention_start_date", "retention_end_date"):
+                if _is_null(_get_field(record, date_field)):
+                    violations.append(
+                        _make_violation(
+                            layout,
+                            record,
+                            date_field,
+                            f"{date_field} is null but retention_status is "
+                            f"'Temporary'.",
+                        )
+                    )
+
+        # Rule 4: Preservation/access records require sound_format.
+        OBJECT_PURPOSES_REQUIRING_SOUND = {"PRESERVATION (FULL)", "ACCESS (CORE)"}
+        object_purpose = _get_field(record, "object_purpose")
+        if object_purpose.upper() in OBJECT_PURPOSES_REQUIRING_SOUND:
+            if _is_null(_get_field(record, "sound_format(1)")):
+                violations.append(
+                    _make_violation(
+                        layout,
+                        record,
+                        "sound_format(1)",
+                        f"sound_format(1) is null but object_purpose is "
+                        f"{object_purpose!r}.",
+                    )
+                )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Per-record validation logic
+# ---------------------------------------------------------------------------
+
+
+def validate_record(layout: str, record: Record) -> list[dict]:
+    """Run all validation checks against the given record for the specified layout.
+
+    Runs:
+      1. Single-field null checks from LAYOUT_VALIDATORS[layout].
+      2. Portal field null checks from _check_portal_fields().
+      3. Cross-field conditional rules from _check_cross_field_rules().
+    Returns a list of violation dicts suitable for output to the report CSV.
+    """
+    violations = []
+    record_dict = record.to_dict()
+
+    # 1. Single-field (flat) checks
+    for field_name, validators in LAYOUT_VALIDATORS.get(layout, {}).items():
         if field_name not in record_dict:
             logger.debug(
-                f"Field {field_name!r} not on record {record.record_id}; skipping."
+                f"[{layout}] Field {field_name!r} not on record "
+                f"{record.record_id}; skipping."
             )
             continue
         value = str(record[field_name] or "")
         for validator in validators:
             for message in validator(value):
-                v = _make_violation(record, field_name, message)
+                v = _make_violation(layout, record, field_name, message)
                 violations.append(v)
                 logger.debug(
-                    f"VIOLATION record_id={record.record_id} "
+                    f"VIOLATION [{layout}] record_id={record.record_id} "
                     f"inventory_id={v['inventory_id']!r} "
                     f"field={field_name!r}: {message}"
                 )
 
-    # 2. Cross-field rules
-    for v in _check_cross_field_rules(record):
+    # 2. Portal field checks
+    for v in _check_portal_fields(layout, record):
         violations.append(v)
         logger.debug(
-            f"VIOLATION (cross-field) record_id={record.record_id} "
-            f"inventory_id={v['inventory_id']!r} "
+            f"VIOLATION (portal) [{layout}] record_id={record.record_id} "
+            f"portal_record_id={v.get('portal_record_id', '')!r} "
             f"field={v['field']!r}: {v['violation']}"
         )
 
-    # 3. Notes field
-    for v in _check_notes_field(record):
+    # 3. Cross-field rules
+    for v in _check_cross_field_rules(layout, record):
         violations.append(v)
         logger.debug(
-            f"VIOLATION (notes) record_id={record.record_id} "
-            f"inventory_id={v['inventory_id']!r}: {v['violation']}"
+            f"VIOLATION (cross-field) [{layout}] record_id={record.record_id} "
+            f"inventory_id={v['inventory_id']!r} "
+            f"field={v['field']!r}: {v['violation']}"
         )
 
     return violations
@@ -338,21 +408,57 @@ def validate_record(record: Record) -> list[dict]:
 
 
 def _write_csv_report(violations: list[dict], output_path: Path) -> None:
-    """Write *violations* to a CSV file at *output_path*.
-
-    :param violations: List of violation dicts from validate_record().
-    :param output_path: Destination path; parent directories are created if needed.
-    """
+    """Write violations dicts to a CSV file at the given path."""
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=REPORT_FIELDNAMES)
+        # Ignore extra dict keys (like 'portal_record_id') so we can keep
+        # that value for logging without forcing it into the CSV.
+        writer = csv.DictWriter(f, fieldnames=REPORT_FIELDNAMES, extrasaction="ignore")
         writer.writeheader()
         writer.writerows(violations)
     logger.info(f"Report written to {output_path} ({len(violations)} violation(s)).")
 
 
 # ---------------------------------------------------------------------------
-# CLI
+# Record retrieval
+# ---------------------------------------------------------------------------
+
+
+def _get_records_for_layout(
+    config: dict,
+    layout: str,
+    args: argparse.Namespace,
+) -> list[Record]:
+    """Initialize a client for the given layout and fetch records."""
+    logger.info(f"Connecting to layout: {layout!r}.")
+    fm_client = fm_utils.initialize_client(config, logger, layout=layout)
+    meta = LAYOUT_METADATA[layout]
+    date_field = meta["date_modified_field"]
+
+    if args.start_date and args.end_date:
+        logger.info(
+            f"[{layout}] Fetching records where {date_field} is between "
+            f"{args.start_date} and {args.end_date}."
+        )
+        records = fm_client.find_all_records(
+            query=[{date_field: f"{args.start_date}...{args.end_date}"}],
+            page_size=args.page_size,
+        )
+        logger.info(f"[{layout}] Found {len(records)} record(s) in date range.")
+    else:
+        logger.info(f"[{layout}] No date range supplied; retrieving all records.")
+        records = fm_utils.get_all_records(
+            fm_client=fm_client,
+            page_size=args.page_size,
+            offset=args.offset,
+            logger=logger,
+        )
+
+    return records
+
+
+# ---------------------------------------------------------------------------
+# CLI arguments
 # ---------------------------------------------------------------------------
 
 
@@ -396,8 +502,9 @@ def _get_arguments() -> argparse.Namespace:
         default=None,
         metavar="MM/DD/YYYY",
         help=(
-            "If provided, only validate records whose `date_modified` field is "
-            "on or after this date. Requires --end_date."
+            "If provided, only validate records modified on or after this date. "
+            "The field used for filtering varies by layout (see LAYOUT_METADATA). "
+            "Requires --end_date."
         ),
     )
     parser.add_argument(
@@ -406,8 +513,19 @@ def _get_arguments() -> argparse.Namespace:
         default=None,
         metavar="MM/DD/YYYY",
         help=(
-            "If provided, only validate records whose `date_modified` field is "
-            "on or before this date. Requires --start_date."
+            "If provided, only validate records modified on or before this date. "
+            "Requires --start_date."
+        ),
+    )
+    parser.add_argument(
+        "--layout",
+        type=str,
+        required=True,
+        choices=list(LAYOUT_VALIDATORS.keys()),
+        help=(
+            "FileMaker layout to validate. Must be one of: "
+            + ", ".join(LAYOUT_VALIDATORS.keys())
+            + "."
         ),
     )
     parser.add_argument(
@@ -416,7 +534,7 @@ def _get_arguments() -> argparse.Namespace:
         default=None,
         help=(
             "Path to write the CSV violation report. "
-            "Defaults to reports/validation_report_YYYYMMDD_HHMMSS.csv."
+            "Defaults to reports/validation_report_{LAYOUT}_{YYYYMMDD_HHMMSS}.csv."
         ),
     )
     return parser.parse_args()
@@ -437,41 +555,30 @@ def main() -> None:
         sys.exit(1)
 
     config = fm_utils.get_config(args.config_file)
-    fm_client = fm_utils.initialize_client(config, logger)
+
+    layout = args.layout
+    logger.info(f"Validating layout: {layout!r}.")
 
     if args.output_csv:
         output_path = Path(args.output_csv)
     else:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        output_path = Path("reports") / f"validation_report_{timestamp}.csv"
+        # Sanitize layout name for use in a filename (replace spaces with underscores).
+        layout_slug = layout.replace(" ", "_")
+        output_path = (
+            Path("reports") / f"validation_report_{layout_slug}_{timestamp}.csv"
+        )
 
     # ---- Fetch records ----
-    if args.start_date and args.end_date:
-        logger.info(
-            f"Fetching records modified between {args.start_date} and {args.end_date}."
-        )
-        records = fm_client.find_all_records(
-            query=[{"date_modified": f"{args.start_date}...{args.end_date}"}],
-            page_size=args.page_size,
-        )
-        logger.info(f"Found {len(records)} record(s) in date range.")
-    else:
-        logger.info("No date range supplied; retrieving all records.")
-        records = fm_utils.get_all_records(
-            fm_client=fm_client,
-            page_size=args.page_size,
-            offset=args.offset,
-            logger=logger,
-        )
+    records = _get_records_for_layout(config, layout, args)
 
     # ---- Validate ----
     all_violations: list[dict] = []
     for record in records:
-        all_violations.extend(validate_record(record))
+        all_violations.extend(validate_record(layout, record))
 
     logger.info(
-        f"Processed {len(records)} record(s); "
-        f"found {len(all_violations)} violation(s)."
+        f"Processed {len(records)} record(s); " f"{len(all_violations)} violation(s)."
     )
 
     # ---- Report ----

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Install `ftva-etl` package
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.3.1
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.3.2
 xmltodict==0.14.2
 # For Excel conversion
 pandas==2.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Install `ftva-etl` package
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.3.2
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.3.3
 xmltodict==0.14.2
 # For Excel conversion
 pandas==2.2.3


### PR DESCRIPTION
Implements [DLSR-329](https://uclalibrary.atlassian.net/browse/DLSR-329) 

Adds a new script, `filemaker_validation_report.py`, that checks each FM record (in a given layout and modification timeframe) against the validation rules defined by the FTVA team ([Google Docs link](https://docs.google.com/document/d/11vt7XdENaFjr-i0IXODXvwFjYK41Fpu-IHVxke9ftEg/edit?tab=t.0)). Violations are collected into a list of dicts and written to a CSV report. Shared FM connection and record-retrieval logic is extracted to `filemaker_utils.py` to avoid duplication with the existing `filemaker_batch_update.py` script.

Sample usage (see README for more details): `python filemaker_validation_report.py --config_file prod_config_secrets.toml --layout "NEW DIGITAL_API" --start_date 05/25/2026 --end_date 06/03/2026`. A log file will be created in `logs/`, and the report CSV will be created in `reports/`.

I experienced timeouts when running the script for a range of more than about 2 weeks against either the `NEW DIGITAL_API` or `InventoryForLabeling_API` layouts. The `NEW DIGITAL STORAGE_API` contains only 2 records, and neither has any violations.

Future work and other notes:
- The script does not currently check the Notes field for violations.
- `filemaker_batch_update.py` needs to be updated to use `filemaker_utils.py`.
- The specs do not actually call for a "reason" column in the report CSV, but I found it helpful in writing and debugging the script and suspect that FTVA users will find it helpful too.


[DLSR-329]: https://uclalibrary.atlassian.net/browse/DLSR-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ