### PR TITLE
DLSR-378: Refactor `generate_metadata.py` to accept batch number

### DIFF
--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -1,4 +1,3 @@
-import csv
 import json
 import argparse
 import tomllib
@@ -13,7 +12,6 @@ from ftva_etl import (
 )
 from ftva_etl.metadata.utils import filter_by_inventory_number_and_library
 from requests.exceptions import HTTPError
-from warnings import deprecated
 from pymarc import Record
 
 
@@ -51,19 +49,22 @@ def configure_logging(console_logging: bool = True) -> None:
 def _get_arguments() -> argparse.Namespace:
     """Parse command line arguments.
 
-    :return: Parsed arguments for config_file, input_file, and
-    output_file as a Namespace object."""
-    parser = argparse.ArgumentParser(description="Process metadata for MAMS ingestion.")
+    :return: Parsed arguments for the program."""
+    parser = argparse.ArgumentParser(
+        description="Prepare JSON metadata for MAMS ingestion."
+    )
     parser.add_argument(
+        "-c",
         "--config_file",
         help="Path to configuration file with API credentials.",
         required=True,
     )
     parser.add_argument(
-        "--input_file",
+        "-b",
+        "--batch_number",
         type=str,
-        required=True,
-        help="Path to the input CSV file containing records to be processed.",
+        required=False,
+        help="Alphanumeric batch number to fetch records from Digital Data.",
     )
     parser.add_argument(
         "--output_dir",
@@ -71,13 +72,6 @@ def _get_arguments() -> argparse.Namespace:
         default="output/",
         required=False,
         help="Path to the output directory where JSON files will be saved. Defaults to 'output/'.",
-    )
-    parser.add_argument(
-        "--split_dpx_audio",
-        action="store_true",
-        required=False,
-        help="If specified, split output JSON into DPX, DPX Audio, and Non-DPX files.",
-        deprecated=True,
     )
     parser.add_argument(
         "--disable_console_logging",
@@ -97,16 +91,6 @@ def _get_config(config_file_name: str) -> dict:
     with open(config_file_name, "rb") as f:
         config = tomllib.load(f)
     return config
-
-
-def _read_input_file(file_path: str) -> list[dict]:
-    """Read the input CSV file and return a list of dictionaries.
-
-    :param file_path: Path to the input CSV file.
-    :return: List of dictionaries representing each row in the CSV file."""
-    with open(file_path, mode="r", encoding="utf-8-sig") as file:
-        reader = csv.DictReader(file)
-        return [row for row in reader]
 
 
 def _write_output_file(output_file: str | Path, data: dict | list[dict]) -> None:
@@ -138,6 +122,34 @@ def _initialize_clients(
             config["digital_data"]["url"],
         ),
     )
+
+
+def _get_records_by_batch_number(
+    batch_number: str,
+    digital_data_client: DigitalDataClient,
+) -> list[dict]:
+    """Get records filtered by batch number from the Digital Data application.
+
+    :param batch_number: The alphanumeric batch number to filter by.
+    :param digital_data_client: The DigitalDataClient instance to use to get the records.
+    :return: A list of records.
+    """
+    all_records: list[dict] = []
+    offset = 0
+    while True:
+        response = digital_data_client.get_records(
+            query=batch_number,
+            fields=["batch_number"],
+            offset=offset,
+        )
+        records = response.get("records", [])
+        all_records.extend(records)
+        offset += len(records)
+        # Break if pagination reaches end of records,
+        # or if a problem causes API to return no records before then.
+        if offset >= response.get("total_records", 0) or not records:
+            break
+    return all_records
 
 
 def _get_alma_bib_record(
@@ -176,78 +188,42 @@ def _get_alma_bib_record(
     return bib_record
 
 
-def _process_input_data(
-    input_data: list[dict],
-    alma_sru_client: AlmaSRUClient,
-    filemaker_client: FilemakerClient,
-    digital_data_client: DigitalDataClient,
-) -> list[dict]:
-    """Process input data and return a list of metadata records, plus counts of assets and tracks.
+def _set_record_type_and_match_asset(
+    digital_data_record: dict, metadata_record: dict
+) -> dict:
+    """Set the `record_type` property on the metadata record,
+    and if applicable, the `match_asset` property for tracks.
 
-    :param input_data: The input data to process.
-    :param alma_sru_client: The AlmaSRUClient instance to use to get the bib record.
-    :param filemaker_client: The FilemakerClient instance to use to get the FM record.
-    :param digital_data_client: The DigitalDataClient instance to use to get the DD record.
-    :return: A list of metadata records.
+    :param digital_data_record: The Digital Data record to process.
+    :param metadata_record: The metadata record to update.
+    :return: The updated metadata record.
     """
-    metadata_records = []
+    # Default to `record_type=asset` for all metadata records
+    metadata_record["record_type"] = "asset"
 
-    for row in input_data:
-        # Adding `try/except` block to prevent the program from crashing if a record
-        # is not found. This would happen if the dev and prod databases are out of sync.
-        try:
-            digital_data_record = digital_data_client.get_record_by_id(
-                row["dl_record_id"]
-            )
-            inventory_number = digital_data_record["inventory_number"]
-
-            bib_record = _get_alma_bib_record(inventory_number, alma_sru_client)
-            if not bib_record:
-                logger.warning(
-                    f"No Alma bib record found for inventory number '{inventory_number}' "
-                    f"on record {row['dl_record_id']}. Proceeding with DD and FM data only."
-                )
-                continue
-
-            filemaker_record = filemaker_client.search_by_inventory_number(
-                inventory_number
-            )[0]
-        except HTTPError as error:
-            if error.response.status_code == 404:
-                logger.error(f"Record {row['dl_record_id']} not found in Digital Data.")
-            else:
-                logger.error(error)
-            continue
-
-        # Initialize to None. Will be set to UUID if record is a track.
-        match_asset_uuid = None
-        if row["Audio Track?"].lower().strip() == "yes":
-            match_asset_uuid = row["match_asset"]
-            if not match_asset_uuid:
-                logger.error(
-                    f"Record {row['dl_record_id']} is marked as a track, "
-                    "but no UUID for the match asset is provided."
-                )
-                continue
-
-        metadata_record = get_mams_metadata(
-            digital_data_record=digital_data_record,
-            filemaker_record=filemaker_record,
-            bib_record=bib_record,
-            match_asset_uuid=match_asset_uuid,
-        )
-
-        # Add temporary field for file_type to be used later for DPX splitting
-        metadata_record["file_type"] = digital_data_record.get("file_type", "")
-
-        metadata_records.append(metadata_record)
-    return metadata_records
+    # Now check if the DD record is a track,
+    # indicated by an incoming relationship with a type of `isTrackOf`
+    incoming_relationships = digital_data_record.get("incoming_relationships", [])
+    # Next() returns the first relationship with a type of `isTrackOf`,
+    # or None if no such relationship is found.
+    track_relationship = next(
+        (
+            relationship
+            for relationship in incoming_relationships
+            if relationship.get("relationship_type", "") == "isTrackOf"
+        ),
+        None,
+    )
+    # If a track relationship is found, set `record_type=track`
+    # and `match_asset` to the source UUID for the relationship.
+    if track_relationship:
+        metadata_record["record_type"] = "track"
+        metadata_record["match_asset"] = track_relationship.get("source_uuid", "")
+    return metadata_record
 
 
-def _update_match_record_type(record_with_match: dict, matched_record: dict) -> dict:
-    """Check if the match_asset relationship is valid between two records. If valid,
-    set record_type to 'track' on the record_with_match. If not valid, set record_type
-    to 'asset'.
+def _compare_inventory_numbers(record_with_match: dict, matched_record: dict) -> dict:
+    """Compare the inventory numbers of two records related via `match_asset`.
 
     :param record_with_match: The record that has a match_asset field.
     :param matched_record: The record that is being matched against.
@@ -287,16 +263,19 @@ def _update_match_record_type(record_with_match: dict, matched_record: dict) -> 
         return record_with_match
 
 
-def _set_record_type(metadata_records: list[dict]) -> list[dict]:
-    """Set the `record_type` for each metadata record based on its `match_asset` value.
+def _validate_match_asset_relationships(metadata_records: list[dict]) -> list[dict]:
+    """Validate that records with a `match_asset` property point to a record in the batch,
+    and that the inventory numbers of the related records match.
 
     :param metadata_records: List of metadata records.
-    :return: List of metadata records with `record_type` set.
+    :return: List of metadata records with validated `record_type` values.
     """
     for record in metadata_records:
-        # If the record has a match_asset value,
-        # validate the relationship and update `record_type` as indicated
+        # If the record has a `match_asset` value,
+        # validate that the value points to a record in the batch,
+        # then compare the inventory numbers of the related records
         if record.get("match_asset"):
+            # Returns first record with a matching UUID, or None if no match is found
             matched_record = next(
                 (r for r in metadata_records if r.get("uuid") == record["match_asset"]),
                 None,
@@ -304,112 +283,80 @@ def _set_record_type(metadata_records: list[dict]) -> list[dict]:
             if not matched_record:
                 logger.error(
                     f"Match asset {record['match_asset']} "
-                    f"for record {record['uuid']} not found in metadata records."
+                    f"for record {record['uuid']} not found in batch."
                 )
                 continue
-            record = _update_match_record_type(record, matched_record)
-        # Else default to 'asset'
-        else:
-            record["record_type"] = "asset"
+            # Compare the inventory numbers of the related records
+            # and overwrite the `record_type` value if necessary
+            record = _compare_inventory_numbers(record, matched_record)
     return metadata_records
 
 
-@deprecated("Metadata records no longer need to be split into separate JSON outputs.")
-def _split_dpx_records(metadata_records: list[dict]) -> dict[str, list[dict]]:
-    """Split metadata records into DPX, DPX Audio, and Non-DPX categories.
+def _process_digital_data_records(
+    digital_data_records: list[dict],
+    alma_sru_client: AlmaSRUClient,
+    filemaker_client: FilemakerClient,
+) -> list[dict]:
+    """Process Digital Data records by passing them to `ftva-etl`,
+    alongside corresponding FileMaker and/or Alma records,
+    then extending the resulting base metadata record with additional properties,
+    to return a list of JSON metadata records.
 
-    :param metadata_records: List of metadata records.
-    :return: A dictionary with keys 'DPX', 'DPX Audio', and 'Non-DPX', each containing
-    a list of corresponding metadata records."""
-    dpx_records = []
-    dpx_audio_records = []
-    non_dpx_records = []
+    :param digital_data_records: Digital Data records to process.
+    :param alma_sru_client: The AlmaSRUClient instance to use to get the bib record.
+    :param filemaker_client: The FilemakerClient instance to use to get the FM record.
+    :return: A list of metadata records for ingest into the MAMS.
+    """
+    metadata_records = []
 
-    # Define audio file types for DPX Audio category
-    audio_file_types = [
-        "WAV",
-        "BWF",
-        "AIFF",
-        "MP3",
-        "AVI",
-        "RM",
-        "RMVB",
-        "AMV",
-        "ASF",
-        "3GPP",
-        "3GGP2",
-    ]
-    # Process each record and categorize
-    # We will do two passes: first for DPX assets, then all others.
-    # This ensures that when processing DPX Audio records, we have already
-    # collected all DPX assets to check for valid match_asset relationships.
-    unassigned_records = metadata_records.copy()
-    for record in metadata_records:
-        inv_list = record.get("inventory_numbers") or []
-        inventory_number = inv_list[0] if len(inv_list) > 0 else None
-        # Categorize records
-        # DPX: file_type = 'DPX', media_type = 'video', asset_type = 'Raw' or 'Intermediate'
-        if (
-            record.get("file_type", "").upper() == "DPX"
-            and record.get("media_type", "").lower() == "video"
-            and record.get("asset_type", "").lower() in ["raw", "intermediate"]
-        ):
-            logger.info(
-                f"DPX record found: Inventory Number '{inventory_number}',"
-                f" UUID '{record.get('uuid')}'. Adding to DPX JSON."
-            )
-            record["record_type"] = "asset"
-            dpx_records.append(record)
-            unassigned_records.remove(record)
+    for digital_data_record in digital_data_records:
+        # Adding `try/except` block to prevent the program from crashing if a record
+        # is not found. This would happen if the dev and prod databases are out of sync.
+        try:
+            inventory_number = digital_data_record["inventory_number"]
 
-    # Second pass for DPX Audio and Non-DPX
-    for record in unassigned_records:
-        inv_list = record.get("inventory_numbers") or []
-        inventory_number = inv_list[0] if len(inv_list) > 0 else None
-        # DPX Audio: file_type in list above, media_type = 'audio', asset_type = 'Raw'
-        if (
-            record.get("file_type", "").upper() in audio_file_types
-            and record.get("media_type", "").lower() == "audio"
-            and record.get("asset_type", "").lower() == "raw"
-        ):
-            logger.info(
-                f"DPX Audio candidate found: Inventory Number '{inventory_number},"
-                f" UUID '{record.get('uuid')}'. Checking match_asset relationship."
-            )
-            # Check for valid match_asset relationship
-            if "match_asset" in record:
-                matched_asset_uuid = record["match_asset"]
-                matched_asset = next(
-                    (r for r in dpx_records if r.get("uuid") == matched_asset_uuid),
-                    None,
+            bib_record = _get_alma_bib_record(inventory_number, alma_sru_client)
+            if not bib_record:
+                logger.warning(
+                    f"No Alma bib record found for inventory number '{inventory_number}' "
+                    f"on DD record {digital_data_record['id']}. "
+                    "Proceeding with DD and FM data only."
                 )
-                if matched_asset:
-                    record = _update_match_record_type(record, matched_asset)
-                if record.get("record_type") == "track":
-                    logger.info(
-                        f"Record with Inventory Number '{inventory_number}' "
-                        "is a valid DPX Audio track. Adding to DPX Audio JSON."
-                    )
-                    dpx_audio_records.append(record)
-                    continue  # Move to next record if it's a valid track
-                elif record.get("record_type") == "asset":
-                    # Treated as individual asset
-                    non_dpx_records.append(record)
-                    continue  # Move to next record if treated as individual asset
+                continue
 
-        # Non-DPX: all other records
-        else:
-            logger.info(
-                f"Non-DPX record found: Inventory Number '{inventory_number},'"
-                f" UUID '{record.get('uuid')}'. Adding to Non-DPX JSON."
-            )
-            record["record_type"] = "asset"
-            non_dpx_records.append(record)
-    return {
-        "DPX": dpx_records,
-        "DPX Audio": dpx_audio_records,
-        "Non-DPX": non_dpx_records,
-    }
+            filemaker_record = filemaker_client.search_by_inventory_number(
+                inventory_number
+            )[0]
+        except HTTPError as error:
+            if error.response.status_code == 404:
+                logger.error(
+                    f"Record {digital_data_record['id']} not found in Digital Data."
+                )
+            else:
+                logger.error(error)
+            continue
+
+        # Run main metadata processing function from `ftva-etl`
+        # to get base metadata record
+        metadata_record = get_mams_metadata(
+            digital_data_record=digital_data_record,
+            filemaker_record=filemaker_record,
+            bib_record=bib_record,
+        )
+
+        # Now extend metadata record with `record_type`,
+        # and `match_asset` for tracks, if applicable.
+        metadata_record = _set_record_type_and_match_asset(
+            digital_data_record, metadata_record
+        )
+
+        # Now add `file_type` property for DPX and DCP records
+        file_type = digital_data_record.get("file_type", "")
+        if file_type in ["DPX", "DCP"]:
+            metadata_record["file_type"] = file_type
+
+        metadata_records.append(metadata_record)
+    return metadata_records
 
 
 def _count_assets_and_tracks(metadata_records: list[dict]) -> tuple[int, int]:
@@ -431,45 +378,32 @@ def main() -> None:
     configure_logging(console_logging=not args.disable_console_logging)
     config = _get_config(args.config_file)
 
-    # Read input file
-    logger.info(f"Loading input data from {args.input_file}")
-    input_data = _read_input_file(args.input_file)
-    logger.info(f"Loaded {len(input_data)} records from input file.")
-
     alma_sru_client, filemaker_client, digital_data_client = _initialize_clients(config)
 
-    metadata_records = _process_input_data(
-        input_data, alma_sru_client, filemaker_client, digital_data_client
+    logger.info(
+        f"Fetching records for batch number {args.batch_number} from Digital Data..."
+    )
+    digital_data_records = _get_records_by_batch_number(
+        args.batch_number, digital_data_client
+    )
+    logger.info(
+        f"Retrieved {len(digital_data_records)} records for batch number {args.batch_number}."
     )
 
-    # Save processed data to JSON file named after the input file.
-    output_filename_stem = Path(args.input_file).stem
-    if args.split_dpx_audio:
-        logger.info("Splitting output JSON into DPX, DPX Audio, and Non-DPX files.")
-        split_data = _split_dpx_records(metadata_records)
-        for key, records in split_data.items():
-            # Remove temporary 'file_type' field before output
-            for record in records:
-                record.pop("file_type", None)
-            output_dict = {"media": {"assets": records}}
-            filename = f"{output_filename_stem}_{key.replace(' ', '_')}.json"
-            _write_output_file(Path(args.output_dir, filename), output_dict)
-        logger.info(f"DPX split JSON files saved to '{args.output_dir}'")
-    else:
-        # Set `record_type` on metadata records
-        metadata_records = _set_record_type(metadata_records)
-        # Remove temporary 'file_type' field before output
-        for record in metadata_records:
-            if record.get("file_type") not in [
-                "DPX",
-                "DCP",
-            ]:  # Keep `file_type` on DPX and DCP records
-                record.pop("file_type", None)
-        output_dict = {"media": {"assets": metadata_records}}
-        _write_output_file(
-            Path(args.output_dir, f"{output_filename_stem}.json"), output_dict
-        )
-        logger.info(f"Output JSON file saved to '{args.output_dir}'")
+    metadata_records = _process_digital_data_records(
+        digital_data_records, alma_sru_client, filemaker_client
+    )
+
+    metadata_records = _validate_match_asset_relationships(metadata_records)
+
+    output_dict = {"media": {"assets": metadata_records}}
+
+    output_filename_stem = f"dd_records_ingest_{args.batch_number}"
+    date_suffix = datetime.now().strftime("%Y-%m-%d")
+    output_path = Path(args.output_dir, f"{output_filename_stem}_{date_suffix}.json")
+    _write_output_file(output_path, output_dict)
+
+    logger.info(f"Output JSON file saved to '{output_path}'")
 
     asset_count, track_count = _count_assets_and_tracks(metadata_records)
     logger.info(

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -2,6 +2,7 @@ import json
 import argparse
 import tomllib
 import logging
+import spacy
 from datetime import datetime
 from pathlib import Path
 from ftva_etl import (
@@ -11,9 +12,10 @@ from ftva_etl import (
     get_mams_metadata,
 )
 from ftva_etl.metadata.utils import filter_by_inventory_number_and_library
-from requests.exceptions import HTTPError
-from pymarc import Record
 
+# For type hints
+from pymarc import Record as Pymarc_Record
+from fmrest.record import Record as FM_Record
 
 # Module-level logger used throughout this module.
 # Handlers are configured explicitly via `configure_logging`.
@@ -63,7 +65,7 @@ def _get_arguments() -> argparse.Namespace:
         "-b",
         "--batch_number",
         type=str,
-        required=False,
+        required=True,
         help="Alphanumeric batch number to fetch records from Digital Data.",
     )
     parser.add_argument(
@@ -97,7 +99,7 @@ def _write_output_file(output_file: str | Path, data: dict | list[dict]) -> None
     """Write processed data to a JSON file.
 
     :param output_file: Path to the output JSON file.
-    :param data: List of dicts containing processed metadata."""
+    :param data: Dict or list of dicts to write to the output file."""
     output_path = Path(output_file)
     # Create parent directories if they don't exist.
     # Allows for `output_file` to be a relative path.
@@ -152,10 +154,10 @@ def _get_records_by_batch_number(
     return all_records
 
 
-def _get_alma_bib_record(
+def _get_alma_bib_record_with_possible_suffix(
     inv_no_stem: str,
     alma_sru_client: AlmaSRUClient,
-) -> Record | None:
+) -> Pymarc_Record | None:
     """Get the Alma bib record for the provided inventory number,
     retrying with suffixes "T", "M", and "R" if no record is found without suffix.
 
@@ -168,13 +170,11 @@ def _get_alma_bib_record(
     # to deal with inconsistent inventory numbers across systems.
     suffixes = ["", "T", "M", "R"]
     inv_nos_to_check = [inv_no_stem + suffix for suffix in suffixes]
-    # There may not be any matches - if so, this is a "1-to-1" record,
-    # so we'll use only DD and FM data.
     bib_record = None
     for inv_no in inv_nos_to_check:
         search_results = alma_sru_client.search_by_call_number(inv_no)
-        filtered_bib_records: list[Record] = filter_by_inventory_number_and_library(
-            search_results, inv_no
+        filtered_bib_records: list[Pymarc_Record] = (
+            filter_by_inventory_number_and_library(search_results, inv_no)
         )
         if filtered_bib_records:
             # Take the first record that matches the inventory number and is from FTVA
@@ -188,175 +188,121 @@ def _get_alma_bib_record(
     return bib_record
 
 
-def _set_record_type_and_match_asset(
-    digital_data_record: dict, metadata_record: dict
-) -> dict:
-    """Set the `record_type` property on the metadata record,
-    and if applicable, the `match_asset` property for tracks.
+def _get_filemaker_record(
+    inventory_number: str,
+    filemaker_client: FilemakerClient,
+) -> FM_Record | None:
+    """Get the FileMaker record for the provided inventory number,
+    or None if no record is found.
 
-    :param digital_data_record: The Digital Data record to process.
-    :param metadata_record: The metadata record to update.
-    :return: The updated metadata record.
+    :param inventory_number: The inventory number to search for.
+    :param filemaker_client: The FilemakerClient instance to use to get the FM record.
+    :return: The FileMaker record, or None if no record is found.
     """
-    # Default to `record_type=asset` for all metadata records
-    metadata_record["record_type"] = "asset"
-
-    # Now check if the DD record is a track,
-    # indicated by an incoming relationship with a type of `isTrackOf`
-    incoming_relationships = digital_data_record.get("incoming_relationships", [])
-    # Next() returns the first relationship with a type of `isTrackOf`,
-    # or None if no such relationship is found.
-    track_relationship = next(
-        (
-            relationship
-            for relationship in incoming_relationships
-            if relationship.get("relationship_type", "") == "isTrackOf"
-        ),
-        None,
-    )
-    # If a track relationship is found, set `record_type=track`
-    # and `match_asset` to the source UUID for the relationship.
-    if track_relationship:
-        metadata_record["record_type"] = "track"
-        metadata_record["match_asset"] = track_relationship.get("source_uuid", "")
-    return metadata_record
+    filemaker_records = filemaker_client.search_by_inventory_number(inventory_number)
+    return filemaker_records[0] if filemaker_records else None
 
 
-def _compare_inventory_numbers(record_with_match: dict, matched_record: dict) -> dict:
-    """Compare the inventory numbers of two records related via `match_asset`.
-
-    :param record_with_match: The record that has a match_asset field.
-    :param matched_record: The record that is being matched against.
-    :return: The updated record_with_match dict with record_type set to 'track' or 'asset'.
-    """
-    asset_inv_list = matched_record.get("inventory_numbers") or []
-    asset_inv = asset_inv_list[0] if len(asset_inv_list) > 0 else None
-    track_inv_list = record_with_match.get("inventory_numbers") or []
-    track_inv = track_inv_list[0] if len(track_inv_list) > 0 else None
-
-    if asset_inv == track_inv:
-        # This is a track
-        record_with_match["record_type"] = "track"
-        logger.info(
-            f"Valid match_asset relationship found for inventory number '{asset_inv}'."
-        )
-        return record_with_match
-
-    elif not asset_inv or not track_inv:
-        # One or both inventory numbers are missing
-        # Treat as individual assets
-        logger.info(
-            f"One or both inventory numbers are missing (asset_inv='{asset_inv}', "
-            f"track_inv='{track_inv}'). Treated as individual assets."
-        )
-        record_with_match["record_type"] = "asset"
-        return record_with_match
-
-    else:
-        # Inventory numbers do not match
-        # Treat as individual assets
-        logger.info(
-            f"Inventory numbers do not match (asset_inv='{asset_inv}', "
-            f"track_inv='{track_inv}'). Treated as individual assets."
-        )
-        record_with_match["record_type"] = "asset"
-        return record_with_match
-
-
-def _validate_match_asset_relationships(metadata_records: list[dict]) -> list[dict]:
-    """Validate that records with a `match_asset` property point to a record in the batch,
-    and that the inventory numbers of the related records match.
-
-    :param metadata_records: List of metadata records.
-    :return: List of metadata records with validated `record_type` values.
-    """
-    for record in metadata_records:
-        # If the record has a `match_asset` value,
-        # validate that the value points to a record in the batch,
-        # then compare the inventory numbers of the related records
-        if record.get("match_asset"):
-            # Returns first record with a matching UUID, or None if no match is found
-            matched_record = next(
-                (r for r in metadata_records if r.get("uuid") == record["match_asset"]),
-                None,
-            )
-            if not matched_record:
-                logger.error(
-                    f"Match asset {record['match_asset']} "
-                    f"for record {record['uuid']} not found in batch."
-                )
-                continue
-            # Compare the inventory numbers of the related records
-            # and overwrite the `record_type` value if necessary
-            record = _compare_inventory_numbers(record, matched_record)
-    return metadata_records
-
-
-def _process_digital_data_records(
+def _get_metadata_records(
     digital_data_records: list[dict],
     alma_sru_client: AlmaSRUClient,
     filemaker_client: FilemakerClient,
 ) -> list[dict]:
-    """Process Digital Data records by passing them to `ftva-etl`,
-    alongside corresponding FileMaker and/or Alma records,
-    then extending the resulting base metadata record with additional properties,
-    to return a list of JSON metadata records.
+    """For each Digital Data record,
+    fetch the corresponding FileMaker record, and possibly the Alma record,
+    then use `ftva_etl` to get the resulting metadata record.
 
     :param digital_data_records: Digital Data records to process.
     :param alma_sru_client: The AlmaSRUClient instance to use to get the bib record.
     :param filemaker_client: The FilemakerClient instance to use to get the FM record.
-    :return: A list of metadata records for ingest into the MAMS.
+    :return: A list of metadata records formatted for ingest into the MAMS.
     """
     metadata_records = []
+    # Load spacy model used by `ftva_etl` once per batch,
+    # to avoid loading it in the package for each record
+    nlp_model = spacy.load("en_core_web_md")
 
     for digital_data_record in digital_data_records:
-        # Adding `try/except` block to prevent the program from crashing if a record
-        # is not found. This would happen if the dev and prod databases are out of sync.
-        try:
-            inventory_number = digital_data_record["inventory_number"]
+        # Use inventory number to find corresponding FM record and possibly Alma record
+        inventory_number = digital_data_record["inventory_number"]
 
-            bib_record = _get_alma_bib_record(inventory_number, alma_sru_client)
-            if not bib_record:
-                logger.warning(
-                    f"No Alma bib record found for inventory number '{inventory_number}' "
-                    f"on DD record {digital_data_record['id']}. "
-                    "Proceeding with DD and FM data only."
-                )
-                continue
+        filemaker_record = _get_filemaker_record(inventory_number, filemaker_client)
+        # Metadata output requires DD-FM match at minimum,
+        # so log an error and skip the current DD record if no FM record is found.
+        if not filemaker_record:
+            logger.error(
+                f"No FileMaker record found for inventory number '{inventory_number}' "
+                f"on DD record {digital_data_record['id']}. "
+                "Skipping current record."
+            )
+            continue  # skip to next DD record
 
-            filemaker_record = filemaker_client.search_by_inventory_number(
-                inventory_number
-            )[0]
-        except HTTPError as error:
-            if error.response.status_code == 404:
-                logger.error(
-                    f"Record {digital_data_record['id']} not found in Digital Data."
-                )
-            else:
-                logger.error(error)
-            continue
+        bib_record = _get_alma_bib_record_with_possible_suffix(
+            inventory_number, alma_sru_client
+        )
+        # Missing Alma record is OK, so log a warning and proceed with batch
+        if not bib_record:
+            logger.warning(
+                f"No Alma bib record found for inventory number '{inventory_number}' "
+                f"on DD record {digital_data_record['id']}. "
+                "Proceeding with DD and FM data only."
+            )
 
-        # Run main metadata processing function from `ftva-etl`
-        # to get base metadata record
+        # Get formatted metadata record from `ftva_etl`
+        # using DD record, corresponding FM record, and possibly Alma record
         metadata_record = get_mams_metadata(
             digital_data_record=digital_data_record,
             filemaker_record=filemaker_record,
-            bib_record=bib_record,
+            bib_record=bib_record,  # can be None if no Alma record found for inv no
+            nlp_model=nlp_model,
         )
-
-        # Now extend metadata record with `record_type`,
-        # and `match_asset` for tracks, if applicable.
-        metadata_record = _set_record_type_and_match_asset(
-            digital_data_record, metadata_record
-        )
-
-        # Now add `file_type` property for DPX and DCP records
-        file_type = digital_data_record.get("file_type", "")
-        if file_type in ["DPX", "DCP"]:
-            metadata_record["file_type"] = file_type
 
         metadata_records.append(metadata_record)
     return metadata_records
+
+
+def _validate_match_asset_relationships(metadata_records: list[dict]) -> bool:
+    """For each metadata record with a `match_asset` field, check that:
+
+    1. the match_asset value actually references another record in the batch; and
+    2. the first inventory numbers of the two related records are the same.
+
+    :param metadata_records: List of metadata records.
+    :return: True if all match_asset relationships are valid, False otherwise.
+    """
+    # Index records by UUID for quick lookup below
+    records_by_uuid = {
+        record["uuid"]: record for record in metadata_records if record.get("uuid")
+    }
+
+    for record in metadata_records:
+        # Skip records without a `match_asset` field
+        match_asset_uuid = record.get("match_asset")
+        if not match_asset_uuid:
+            continue
+
+        matched_record = records_by_uuid.get(match_asset_uuid)
+        # Fail validation if the match_asset is not found in the batch
+        if not matched_record:
+            logger.error(
+                f"Match asset {match_asset_uuid} for record {record['uuid']} "
+                f"not found in batch."
+            )
+            return False
+
+        # Now check inventory numbers, using the first inv no for each record
+        record_inv = (record.get("inventory_numbers") or [None])[0]
+        matched_record_inv = (matched_record.get("inventory_numbers") or [None])[0]
+
+        # Fail validation if inventory numbers do not match
+        if record_inv != matched_record_inv:
+            logger.error(
+                f"Inventory numbers do not match for match_asset relationship "
+                f"{record['record_type']} {record['uuid']}: '{record_inv}', "
+                f"{matched_record['record_type']} {matched_record['uuid']}: '{matched_record_inv}'"
+            )
+            return False
+    return True
 
 
 def _count_assets_and_tracks(metadata_records: list[dict]) -> tuple[int, int]:
@@ -390,11 +336,16 @@ def main() -> None:
         f"Retrieved {len(digital_data_records)} records for batch number {args.batch_number}."
     )
 
-    metadata_records = _process_digital_data_records(
+    metadata_records = _get_metadata_records(
         digital_data_records, alma_sru_client, filemaker_client
     )
 
-    metadata_records = _validate_match_asset_relationships(metadata_records)
+    # If match_asset relationships are invalid, log an error and exit
+    if not _validate_match_asset_relationships(metadata_records):
+        logger.error(
+            "Invalid match_asset relationships found in metadata records. Review logs for details."
+        )
+        return
 
     output_dict = {"media": {"assets": metadata_records}}
 

--- a/generate_metadata.py
+++ b/generate_metadata.py
@@ -158,12 +158,13 @@ def _get_alma_bib_record_with_possible_suffix(
     inv_no_stem: str,
     alma_sru_client: AlmaSRUClient,
 ) -> Pymarc_Record | None:
-    """Get the Alma bib record for the provided inventory number,
+    """Get the first matching Alma bib record for the provided inventory number,
     retrying with suffixes "T", "M", and "R" if no record is found without suffix.
 
     :param inv_no_stem: The base inventory number to search for.
     :param alma_sru_client: The AlmaSRUClient instance to use to get the bib record.
-    :return: Matching Alma bib record, or None if no record is found.
+    :return: The first Alma record matching the inventory number,
+        or None if no record is found.
     """
     # Try no suffix first, then "T", "M", and "R".
     # NOTE: The additional suffixes are a shim
@@ -192,14 +193,16 @@ def _get_filemaker_record(
     inventory_number: str,
     filemaker_client: FilemakerClient,
 ) -> FM_Record | None:
-    """Get the FileMaker record for the provided inventory number,
+    """Get the first matching FileMaker record for the provided inventory number,
     or None if no record is found.
 
     :param inventory_number: The inventory number to search for.
     :param filemaker_client: The FilemakerClient instance to use to get the FM record.
-    :return: The FileMaker record, or None if no record is found.
+    :return: The first FileMaker record matching inventory number,
+        or None if no record is found.
     """
     filemaker_records = filemaker_client.search_by_inventory_number(inventory_number)
+    # If search returns multiple records, return only the first
     return filemaker_records[0] if filemaker_records else None
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Install `ftva-etl` package
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.4.0
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.5.0
 xmltodict==0.14.2
 # For Excel conversion
 pandas==2.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Install `ftva-etl` package
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.3.3
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.4.0
 xmltodict==0.14.2
 # For Excel conversion
 pandas==2.2.3

--- a/tests/test_generate_metadata.py
+++ b/tests/test_generate_metadata.py
@@ -3,8 +3,9 @@ import io
 import logging
 
 from generate_metadata import (
-    _set_record_type,
-    _update_match_record_type,
+    _set_record_type_and_match_asset,
+    _validate_match_asset_relationships,
+    _compare_inventory_numbers,
     logger,
 )
 
@@ -36,27 +37,55 @@ class TestGenerateMetadata(unittest.TestCase):
             handler.close()
             self.logger.removeHandler(handler)
 
-    def test_set_record_type_with_match_asset(self):
-        """Test that `_set_record_type` sets the `record_type` correctly
-        when there is a `match_asset` relationship.
-        """
-        # Tuple of test records and expected results
-        test_records = [
+    def test_set_record_type_and_match_asset(self):
+        """Test that `_set_record_type_and_match_asset`
+        sets `record_type` and `match_asset` correctly."""
+        test_digital_data_records = [
             {
                 "uuid": "12345",
                 "inventory_numbers": ["INV001"],
-            },  # should be asset
+            },
             {
                 "uuid": "67890",
                 "inventory_numbers": ["INV002"],
-            },  # should be asset
-            {
-                "uuid": "09876",
-                "inventory_numbers": ["INV001"],
-                "match_asset": "12345",
-            },  # since inventory numbers match the target match_asset, should be track
+                "incoming_relationships": [
+                    {
+                        "relationship_type": "isTrackOf",
+                        "source_uuid": "12345",
+                    }
+                ],
+            },  # track relationship indicated in DD record targeting asset 12345
         ]
         expected_results = [
+            {
+                "uuid": "12345",
+                "inventory_numbers": ["INV001"],
+                "record_type": "asset",
+            },  # this output should be an asset
+            {
+                "uuid": "67890",
+                "inventory_numbers": ["INV002"],
+                "record_type": "track",
+                "match_asset": "12345",
+            },  # this output should be a track, with match_asset set to UUID of the asset
+        ]
+
+        # Zip together the two lists to get tuples of (dd_record, expected_result)
+        for dd_record, expected_result in zip(
+            test_digital_data_records, expected_results
+        ):
+            with self.subTest(dd_record=dd_record, expected_result=expected_result):
+                metadata_record = _set_record_type_and_match_asset(
+                    dd_record, expected_result
+                )
+                self.assertEqual(metadata_record, expected_result)
+
+    def test_validate_match_asset_relationships_with_valid_match_asset(self):
+        """Test that `_validate_match_asset_relationships`
+        leaves the `record_type` and `match_asset` values unchanged
+        when the `match_asset` relationship is valid.
+        """
+        test_records = [
             {
                 "uuid": "12345",
                 "inventory_numbers": ["INV001"],
@@ -72,31 +101,17 @@ class TestGenerateMetadata(unittest.TestCase):
                 "inventory_numbers": ["INV001"],
                 "match_asset": "12345",
                 "record_type": "track",
-            },
+            },  # valid match_asset relationship, so should be unchanged
         ]
 
-        result_records = _set_record_type(test_records)
-        self.assertEqual(result_records, expected_results)
+        result_records = _validate_match_asset_relationships(test_records)
+        self.assertEqual(result_records, test_records)
 
-    def test_set_record_type_without_match_asset(self):
-        """Test that `_set_record_type` sets the `record_type` correctly
-        when there is no `match_asset` relationship.
+    def test_validate_match_asset_relationships_without_match_asset(self):
+        """Test that `_validate_match_asset_relationships`
+        sets the `record_type` correctly when there is no `match_asset` relationship.
         """
         test_records = [
-            {
-                "uuid": "12345",
-                "inventory_numbers": ["INV001"],
-            },  # should be asset
-            {
-                "uuid": "67890",
-                "inventory_numbers": ["INV002"],
-            },  # should be asset
-            {
-                "uuid": "09876",
-                "inventory_numbers": ["INV001"],
-            },  # since there is no match_asset relationship, should be asset
-        ]
-        expected_results = [
             {
                 "uuid": "12345",
                 "inventory_numbers": ["INV001"],
@@ -114,43 +129,37 @@ class TestGenerateMetadata(unittest.TestCase):
             },
         ]
 
-        result_records = _set_record_type(test_records)
-        self.assertEqual(result_records, expected_results)
+        result_records = _validate_match_asset_relationships(test_records)
+        # All test records should remain `assets`, since there is no match_asset relationship.
+        self.assertEqual(result_records, test_records)
 
-    def test_set_record_type_when_match_asset_is_missing(self):
-        """Test that `_set_record_type` skips records
-        when the `match_asset` cannot be found and logs an error.
+    def test_validate_match_asset_relationships_when_match_asset_is_missing(self):
+        """Test that `_validate_match_asset_relationships` logs an error
+        when the targeted `match_asset` record is not in the batch.
         """
         test_records = [
-            {"uuid": "12345", "inventory_numbers": ["INV001"]},
-            {"uuid": "67890", "inventory_numbers": ["INV002"]},
-            {
-                "uuid": "09876",
-                "inventory_numbers": ["INV001"],
-                "match_asset": "34567",
-            },  # should be skipped, because target match_asset does not exist
-        ]
-        expected_results = [
             {"uuid": "12345", "inventory_numbers": ["INV001"], "record_type": "asset"},
             {"uuid": "67890", "inventory_numbers": ["INV002"], "record_type": "asset"},
             {
                 "uuid": "09876",
                 "inventory_numbers": ["INV001"],
-                "match_asset": "34567",
+                "match_asset": "34567",  # missing from "batch", i.e. `test_records`
+                "record_type": "track",
             },  # there should be an error in logs about the missing match_asset
         ]
 
-        result_records = _set_record_type(test_records)
-        self.assertEqual(result_records, expected_results)
-        # `_set_record_type` should log an error about the missing match_asset.
+        result_records = _validate_match_asset_relationships(test_records)
+        # Test records should remain unchanged
+        self.assertEqual(result_records, test_records)
+        # `_validate_match_asset_relationships` should log an error about the missing match_asset.
         # Check for it here in the test IO stream being used as the test log handler.
         self.assertIn(
-            "ERROR: Match asset 34567 for record 09876 not found in metadata records.",
+            "ERROR: Match asset 34567 for record 09876 not found in batch.",
             self.stream.getvalue(),
         )
 
-    def test_update_match_record_type_with_valid_match_asset(self):
-        """Test that `_update_match_record_type` updates the `record_type` correctly
+    def test_compare_inventory_numbers_with_valid_match_asset(self):
+        """Test that `_compare_inventory_numbers` updates the `record_type` correctly
         when there is a valid `match_asset` relationship.
         """
         # Test cases comprised of (record with match, matched record, expected_result)
@@ -211,7 +220,7 @@ class TestGenerateMetadata(unittest.TestCase):
         for test_case in test_cases:
             with self.subTest(test_case=test_case):
                 test_record, test_matched_record, expected_result = test_case
-                result_record = _update_match_record_type(
+                result_record = _compare_inventory_numbers(
                     test_record, test_matched_record
                 )
                 self.assertEqual(result_record, expected_result)

--- a/tests/test_generate_metadata.py
+++ b/tests/test_generate_metadata.py
@@ -3,9 +3,7 @@ import io
 import logging
 
 from generate_metadata import (
-    _set_record_type_and_match_asset,
     _validate_match_asset_relationships,
-    _compare_inventory_numbers,
     logger,
 )
 
@@ -37,53 +35,9 @@ class TestGenerateMetadata(unittest.TestCase):
             handler.close()
             self.logger.removeHandler(handler)
 
-    def test_set_record_type_and_match_asset(self):
-        """Test that `_set_record_type_and_match_asset`
-        sets `record_type` and `match_asset` correctly."""
-        test_digital_data_records = [
-            {
-                "uuid": "12345",
-                "inventory_numbers": ["INV001"],
-            },
-            {
-                "uuid": "67890",
-                "inventory_numbers": ["INV002"],
-                "incoming_relationships": [
-                    {
-                        "relationship_type": "isTrackOf",
-                        "source_uuid": "12345",
-                    }
-                ],
-            },  # track relationship indicated in DD record targeting asset 12345
-        ]
-        expected_results = [
-            {
-                "uuid": "12345",
-                "inventory_numbers": ["INV001"],
-                "record_type": "asset",
-            },  # this output should be an asset
-            {
-                "uuid": "67890",
-                "inventory_numbers": ["INV002"],
-                "record_type": "track",
-                "match_asset": "12345",
-            },  # this output should be a track, with match_asset set to UUID of the asset
-        ]
-
-        # Zip together the two lists to get tuples of (dd_record, expected_result)
-        for dd_record, expected_result in zip(
-            test_digital_data_records, expected_results
-        ):
-            with self.subTest(dd_record=dd_record, expected_result=expected_result):
-                metadata_record = _set_record_type_and_match_asset(
-                    dd_record, expected_result
-                )
-                self.assertEqual(metadata_record, expected_result)
-
     def test_validate_match_asset_relationships_with_valid_match_asset(self):
         """Test that `_validate_match_asset_relationships`
-        leaves the `record_type` and `match_asset` values unchanged
-        when the `match_asset` relationship is valid.
+        returns True when all match_asset relationships are valid.
         """
         test_records = [
             {
@@ -101,15 +55,14 @@ class TestGenerateMetadata(unittest.TestCase):
                 "inventory_numbers": ["INV001"],
                 "match_asset": "12345",
                 "record_type": "track",
-            },  # valid match_asset relationship, so should be unchanged
+            },  # valid match_asset relationship: both match_asset and inv no match target
         ]
-
-        result_records = _validate_match_asset_relationships(test_records)
-        self.assertEqual(result_records, test_records)
+        result = _validate_match_asset_relationships(test_records)
+        self.assertTrue(result)
 
     def test_validate_match_asset_relationships_without_match_asset(self):
         """Test that `_validate_match_asset_relationships`
-        sets the `record_type` correctly when there is no `match_asset` relationship.
+        returns True when there are no `match_asset` relationships.
         """
         test_records = [
             {
@@ -129,13 +82,13 @@ class TestGenerateMetadata(unittest.TestCase):
             },
         ]
 
-        result_records = _validate_match_asset_relationships(test_records)
-        # All test records should remain `assets`, since there is no match_asset relationship.
-        self.assertEqual(result_records, test_records)
+        result = _validate_match_asset_relationships(test_records)
+        self.assertTrue(result)
 
     def test_validate_match_asset_relationships_when_match_asset_is_missing(self):
-        """Test that `_validate_match_asset_relationships` logs an error
-        when the targeted `match_asset` record is not in the batch.
+        """Test that `_validate_match_asset_relationships`
+        returns False and logs expected error
+        when the targeted `match_asset` record is missing.
         """
         test_records = [
             {"uuid": "12345", "inventory_numbers": ["INV001"], "record_type": "asset"},
@@ -143,84 +96,41 @@ class TestGenerateMetadata(unittest.TestCase):
             {
                 "uuid": "09876",
                 "inventory_numbers": ["INV001"],
-                "match_asset": "34567",  # missing from "batch", i.e. `test_records`
+                "match_asset": "34567",  # this value is missing
                 "record_type": "track",
-            },  # there should be an error in logs about the missing match_asset
+            },
         ]
 
-        result_records = _validate_match_asset_relationships(test_records)
-        # Test records should remain unchanged
-        self.assertEqual(result_records, test_records)
-        # `_validate_match_asset_relationships` should log an error about the missing match_asset.
-        # Check for it here in the test IO stream being used as the test log handler.
+        result = _validate_match_asset_relationships(test_records)
+        self.assertFalse(result)
+        # There should be an error in logs about the missing target
         self.assertIn(
             "ERROR: Match asset 34567 for record 09876 not found in batch.",
             self.stream.getvalue(),
         )
 
-    def test_compare_inventory_numbers_with_valid_match_asset(self):
-        """Test that `_compare_inventory_numbers` updates the `record_type` correctly
-        when there is a valid `match_asset` relationship.
+    def test_validate_match_asset_relationships_when_inv_nos_do_not_match(self):
+        """Test that `_validate_match_asset_relationships`
+        returns False and logs expected error
+        when the inventory numbers of the match_asset and target record do not match.
         """
-        # Test cases comprised of (record with match, matched record, expected_result)
-        test_cases = (
-            (
-                {
-                    "uuid": "09876",
-                    "inventory_numbers": ["INV001"],
-                    "match_asset": "12345",
-                },  # record with match
-                {
-                    "uuid": "12345",
-                    "inventory_numbers": ["INV001"],
-                },  # matched record
-                {
-                    "uuid": "09876",
-                    "inventory_numbers": ["INV001"],
-                    "match_asset": "12345",
-                    "record_type": "track",
-                },  # expected result
-            ),  # where inventory numbers match the target match_asset, should be track
-            (
-                {
-                    "uuid": "09876",
-                    "inventory_numbers": ["INV002"],
-                    "match_asset": "12345",
-                },  # record with match
-                {
-                    "uuid": "12345",
-                    "inventory_numbers": ["INV001"],
-                },  # matched record
-                {
-                    "uuid": "09876",
-                    "inventory_numbers": ["INV002"],
-                    "match_asset": "12345",
-                    "record_type": "asset",
-                },  # expected result
-            ),  # where inventory numbers do not match the target match_asset, should be asset
-            (
-                {
-                    "uuid": "09876",
-                    "inventory_numbers": [],
-                    "match_asset": "12345",
-                },  # record with match
-                {
-                    "uuid": "12345",
-                    "inventory_numbers": ["INV001"],
-                },  # matched record
-                {
-                    "uuid": "09876",
-                    "inventory_numbers": [],
-                    "match_asset": "12345",
-                    "record_type": "asset",
-                },  # expected result
-            ),  # where either inventory number is missing, should be asset
-        )
+        test_records = [
+            {"uuid": "12345", "inventory_numbers": ["INV001"], "record_type": "asset"},
+            {"uuid": "67890", "inventory_numbers": ["INV002"], "record_type": "asset"},
+            {
+                "uuid": "09876",
+                "inventory_numbers": ["INV003"],  # inv no does not match the target
+                "match_asset": "12345",
+                "record_type": "track",
+            },
+        ]
 
-        for test_case in test_cases:
-            with self.subTest(test_case=test_case):
-                test_record, test_matched_record, expected_result = test_case
-                result_record = _compare_inventory_numbers(
-                    test_record, test_matched_record
-                )
-                self.assertEqual(result_record, expected_result)
+        result = _validate_match_asset_relationships(test_records)
+        self.assertFalse(result)
+        self.assertIn(
+            (
+                "ERROR: Inventory numbers do not match for match_asset relationship "
+                "track 09876: 'INV003', asset 12345: 'INV001'"
+            ),
+            self.stream.getvalue(),
+        )


### PR DESCRIPTION
Implements [DLSR-378](https://uclalibrary.atlassian.net/browse/DLSR-378)

### Acceptance criteria
- [X] Modify `generate_metadata.py` to accept a `batch_number` argument
- [X] Retrieve data from Digital Data application by `batch_number` instead of using `input_file`
- [X] Set asset/track relationships using data from DD app
- [X] Remove `input_file` support

### Description
**Update:** This PR is now intended to work with [recent changes](https://github.com/UCLALibrary/ftva-etl/pull/35) to the `ftva_etl` package. [See comment](https://github.com/UCLALibrary/ftva-mams-data/pull/57#issuecomment-4804494317) below for more info.

<s>Refactors `generate_metadata.py` to fetch a specified batch of records from the Digital Data app using the new filtering support. Much of the logic remains in place, with some functions renamed for clarity. The `input_file` argument and its related functions are removed.

The most significant change to logic relates to the `record_type` and `match_asset` properties on the output metadata. Previously, these were set via the input file; if a record was a track, it would have its `match_asset` field set to the UUID of its parent asset in the input file. Now, these relationships are derived from the `incoming_relationships` field on the records fetched from Digital Data. The idea is, while looping through the Digital Data records, we default to treating everything as an asset. Then, if we find a record with an incoming relationship of type `isTrackOf`, then we set it to `record_type=track` and set its `match_asset` accordingly. **Notably, this takes the first `isTrackOf` relationship from Digital Data; a single DD record could be a track of more than one asset, but that's not handled here.**

`ftva-etl` is also bumped to `v0.4.0` in `requirements.txt`.</s>

### Testing
Using batch `3c` as a reference, I compared the original JSON output to a newly generated output. The original output file is named `dd_records_ingest_03c_2026-04-09.json`, and I sent it to Christina on [Slack](https://uclalibrary.slack.com/archives/C0893DA0TL0/p1775756564715239?thread_ts=1775671069.228839&cid=C0893DA0TL0). Let me know if it's inaccessible, and I'll resend it. After regenerating batch `3c`, I used the scratch program below to make sure the outputs were sorted in the same way, allowing for a clean diff.

To replicate, run `python generate_metadata.py -c config_dev.toml -b 3c` against the production Digital Data instance, then run:

```python
import json

data_a = json.load(open("{{PATH_TO_ORIGINAL_OUTPUT_FILE}}"))  # change this
data_b = json.load(open("{{PATH_TO_NEW_OUTPUT_FILE}}"))  # change this

# Sort the assets by UUID
data_a["media"]["assets"].sort(key=lambda x: x["uuid"])
data_b["media"]["assets"].sort(key=lambda x: x["uuid"])

# Now make sure the keys are in the same order
data_a["media"]["assets"] = [
    {k: asset[k] for k in sorted(asset)} for asset in data_a["media"]["assets"]
]
data_b["media"]["assets"] = [
    {k: asset[k] for k in sorted(asset)} for asset in data_b["media"]["assets"]
]

json.dump(data_a, open("output/output_a_ordered.json", "w"), indent=4)
json.dump(data_b, open("output/output_b_ordered.json", "w"), indent=4)
```

Perhaps there's a way to do this using `jq`, but I don't know `jq` very well. Diff the resulting outputs however you prefer; there should be one small difference in a date value, but that must have changed after the JSON was generated originally.

[DLSR-378]: https://uclalibrary.atlassian.net/browse/DLSR-378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ