### PR TITLE
DLSR-399: updates to FM validation report script

### DIFF
--- a/filemaker_validation_report.py
+++ b/filemaker_validation_report.py
@@ -146,12 +146,12 @@ LAYOUT_VALIDATORS: dict[str, dict[str, list[Callable]]] = {
         "donor_code": [_check_null],
         "Acquisition type": [_check_null],
         "type": [_check_null],
-        "item_unit_holdings": [_check_null],
+        "item holdings Count": [_check_null],
         "title": [_check_null],
         "date_received": [_check_null],
         "director": [_check_null],
         "release_broadcast_year": [_check_null],  # cross-field rule also applies
-        "format": [_check_null],
+        "format_type": [_check_null],
         "inventory_no": [_check_null],
     },
     # NDM Digital Carrier layout


### PR DESCRIPTION
Implements [DLSR-399](https://uclalibrary.atlassian.net/browse/DLSR-399)

A few small changes to `filemaker_validation_report.py` to implement the three changes highlighted in yellow in the latest version of the Google Doc specs: https://docs.google.com/document/d/11vt7XdENaFjr-i0IXODXvwFjYK41Fpu-IHVxke9ftEg/edit?tab=t.0

Namely, the changes are:
1. Check `item_unit_holdings` for null values only in the NDM layout (was previously NDM and GE).
2. Check `item holdings Count` for null values in the GE layout (was previously not included in the specs).
3. Check `format_type` instead of `format` in the GE layout.

These are entirely implemented with changes to field names in `LAYOUT_VALIDATORS` for the GE form. Output files were sent to Thelma in Slack for FTVA review. Example to run it yourself: `python filemaker_validation_report.py --config_file prod_config_secrets.toml --layout "InventoryForLabeling_API" --start_date 06/01/2026 --end_date 06/24/2026`

[DLSR-399]: https://uclalibrary.atlassian.net/browse/DLSR-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ