### PR TITLE
DLSR-420: use 'item holdings' in FM validation report

### DIFF
--- a/filemaker_validation_report.py
+++ b/filemaker_validation_report.py
@@ -146,7 +146,7 @@ LAYOUT_VALIDATORS: dict[str, dict[str, list[Callable]]] = {
         "donor_code": [_check_null],
         "Acquisition type": [_check_null],
         "type": [_check_null],
-        "item holdings Count": [_check_null],
+        "item holdings": [_check_null],
         "title": [_check_null],
         "date_received": [_check_null],
         "director": [_check_null],


### PR DESCRIPTION
Implements [DLSR-420](https://uclalibrary.atlassian.net/browse/DLSR-420)

Per Slack conversation with Thelma this morning, the field `item holdings Count` should be removed from the FM validation report, and `item holdings` should be checked for null values again (for the GE layout). Requirements document has also been updated: https://docs.google.com/document/d/11vt7XdENaFjr-i0IXODXvwFjYK41Fpu-IHVxke9ftEg 

Running the new report shows one record with a null value for the month of June. In general, these values do seem to make sense as item counts - most are small numbers (0-10), some are blanks, and there are some irregular values.




[DLSR-420]: https://uclalibrary.atlassian.net/browse/DLSR-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ