### PR TITLE
DLSR-463: Make inventory number check optional

### DIFF
--- a/generate_metadata_legacy_media.py
+++ b/generate_metadata_legacy_media.py
@@ -209,13 +209,14 @@ def main() -> None:
         digital_data_records, alma_sru_client, filemaker_client
     )
 
-    # If match_asset relationships are invalid, log an error and exit
-    if not gm_utils.validate_match_asset_relationships(
-        metadata_records=metadata_records,
-        logger=LOGGER,
-    ):
+    # If there are any validation problems, log them and exit without writing output file
+    validation_problems = gm_utils.validate_match_asset_relationships(metadata_records)
+    if validation_problems:
+        for problem in validation_problems:
+            LOGGER.error(problem)
         LOGGER.error(
-            "Invalid match_asset relationships found in metadata records. Review logs for details."
+            "Problems found with match_asset relationships. "
+            "Please fix the issues and try again."
         )
         return
 

--- a/generate_metadata_legacy_media.py
+++ b/generate_metadata_legacy_media.py
@@ -210,7 +210,10 @@ def main() -> None:
     )
 
     # If match_asset relationships are invalid, log an error and exit
-    if not gm_utils.validate_match_asset_relationships(metadata_records):
+    if not gm_utils.validate_match_asset_relationships(
+        metadata_records=metadata_records,
+        logger=LOGGER,
+    ):
         LOGGER.error(
             "Invalid match_asset relationships found in metadata records. Review logs for details."
         )

--- a/generate_metadata_new_media.py
+++ b/generate_metadata_new_media.py
@@ -180,7 +180,12 @@ def main() -> None:
     metadata_records = _get_metadata_records(config, input_data)
 
     # If match_asset relationships are invalid, log an error and exit
-    if not gm_utils.validate_match_asset_relationships(metadata_records):
+    # Inventory numbers are expected to differ for NDM, so we disable inventory number validation.
+    if not gm_utils.validate_match_asset_relationships(
+        metadata_records=metadata_records,
+        check_inventory_numbers=False,
+        logger=LOGGER,
+    ):
         LOGGER.error(
             "Invalid match_asset relationships found in metadata records. Review logs for details."
         )

--- a/generate_metadata_new_media.py
+++ b/generate_metadata_new_media.py
@@ -179,15 +179,17 @@ def main() -> None:
 
     metadata_records = _get_metadata_records(config, input_data)
 
-    # If match_asset relationships are invalid, log an error and exit
+    # If there are any validation problems, log them and exit without writing output file.
     # Inventory numbers are expected to differ for NDM, so we disable inventory number validation.
-    if not gm_utils.validate_match_asset_relationships(
-        metadata_records=metadata_records,
-        check_inventory_numbers=False,
-        logger=LOGGER,
-    ):
+    validation_problems = gm_utils.validate_match_asset_relationships(
+        metadata_records, check_inventory_numbers=False
+    )
+    if validation_problems:
+        for problem in validation_problems:
+            LOGGER.error(problem)
         LOGGER.error(
-            "Invalid match_asset relationships found in metadata records. Review logs for details."
+            "Problems found with match_asset relationships. "
+            "Please fix the issues and try again."
         )
         return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Install `ftva-etl` package
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.5.1
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.6.0
 xmltodict==0.14.2
 # For Excel conversion
 pandas==2.2.3

--- a/tests/test_generate_metadata_utils.py
+++ b/tests/test_generate_metadata_utils.py
@@ -100,7 +100,31 @@ class TestGenerateMetadata(unittest.TestCase):
             result = validate_match_asset_relationships(test_records)
             self.assertFalse(result)
             self.assertIn(
-                "Inventory numbers do not match for match_asset relationship "
+                "Inventory numbers do not match for match_asset relationship: "
                 "track 09876: 'INV003', asset 12345: 'INV001'",
                 context_manager.output[0],
             )
+
+    def test_validate_match_asset_relationships_with_check_inventory_numbers_false(self):
+        """Test that `validate_match_asset_relationships`
+        returns True when `check_inventory_numbers` is False,
+        even if the inventory numbers of the match_asset and target record do not match.
+        """
+        test_records = [
+            {"uuid": "12345", "inventory_numbers": ["INV001"], "record_type": "asset"},
+            {"uuid": "67890", "inventory_numbers": ["INV002"], "record_type": "asset"},
+            {
+                "uuid": "09876",
+                "inventory_numbers": ["INV003"],  # inv no does not match the target
+                "match_asset": "12345",
+                "record_type": "track",
+            },
+        ]
+
+        # There should be no log messages emitted here,
+        # since `check_inventory_numbers` is set to False
+        with self.assertNoLogs():
+            result = validate_match_asset_relationships(
+                test_records, check_inventory_numbers=False
+            )
+            self.assertTrue(result)

--- a/tests/test_generate_metadata_utils.py
+++ b/tests/test_generate_metadata_utils.py
@@ -8,7 +8,7 @@ class TestGenerateMetadata(unittest.TestCase):
 
     def test_validate_match_asset_relationships_with_valid_match_asset(self):
         """Test that `validate_match_asset_relationships`
-        returns True when all match_asset relationships are valid.
+        returns empty list when all match_asset relationships are valid.
         """
         test_records = [
             {
@@ -29,11 +29,12 @@ class TestGenerateMetadata(unittest.TestCase):
             },  # valid match_asset relationship: both match_asset and inv no match target
         ]
         result = validate_match_asset_relationships(test_records)
-        self.assertTrue(result)
+        # When all match_asset relationships are valid, result should be empty list
+        self.assertEqual(result, [])
 
     def test_validate_match_asset_relationships_without_match_asset(self):
         """Test that `validate_match_asset_relationships`
-        returns True when there are no `match_asset` relationships.
+        returns empty list when there are no `match_asset` relationships.
         """
         test_records = [
             {
@@ -52,13 +53,13 @@ class TestGenerateMetadata(unittest.TestCase):
                 "record_type": "asset",
             },
         ]
-
         result = validate_match_asset_relationships(test_records)
-        self.assertTrue(result)
+        # When no match_asset relationships, result should be empty list
+        self.assertEqual(result, [])
 
     def test_validate_match_asset_relationships_when_match_asset_is_missing(self):
         """Test that `validate_match_asset_relationships`
-        returns False and logs expected error
+        returns list of validation problems
         when the targeted `match_asset` record is missing.
         """
         test_records = [
@@ -72,17 +73,16 @@ class TestGenerateMetadata(unittest.TestCase):
             },
         ]
 
-        with self.assertLogs(level="ERROR") as context_manager:
-            result = validate_match_asset_relationships(test_records)
-            self.assertFalse(result)
-            self.assertIn(
-                "Match asset 34567 for record 09876 not found in batch.",
-                context_manager.output[0],
-            )
+        result = validate_match_asset_relationships(test_records)
+        # Result should contain one message, since there is one missing match_asset relationship
+        self.assertEqual(
+            result,
+            ["Match asset 34567 for record 09876 not found in batch."],
+        )
 
     def test_validate_match_asset_relationships_when_inv_nos_do_not_match(self):
         """Test that `validate_match_asset_relationships`
-        returns False and logs expected error
+        returns list of validation problems
         when the inventory numbers of the match_asset and target record do not match.
         """
         test_records = [
@@ -96,16 +96,19 @@ class TestGenerateMetadata(unittest.TestCase):
             },
         ]
 
-        with self.assertLogs(level="ERROR") as context_manager:
-            result = validate_match_asset_relationships(test_records)
-            self.assertFalse(result)
-            self.assertIn(
+        result = validate_match_asset_relationships(test_records)
+        # Result should contain one message, since there is one inv no mismatch
+        self.assertEqual(
+            result,
+            [
                 "Inventory numbers do not match for match_asset relationship: "
-                "track 09876: 'INV003', asset 12345: 'INV001'",
-                context_manager.output[0],
-            )
+                "track 09876: 'INV003', asset 12345: 'INV001'"
+            ],
+        )
 
-    def test_validate_match_asset_relationships_with_check_inventory_numbers_false(self):
+    def test_validate_match_asset_relationships_with_check_inventory_numbers_false(
+        self,
+    ):
         """Test that `validate_match_asset_relationships`
         returns True when `check_inventory_numbers` is False,
         even if the inventory numbers of the match_asset and target record do not match.
@@ -121,10 +124,8 @@ class TestGenerateMetadata(unittest.TestCase):
             },
         ]
 
-        # There should be no log messages emitted here,
-        # since `check_inventory_numbers` is set to False
-        with self.assertNoLogs():
-            result = validate_match_asset_relationships(
-                test_records, check_inventory_numbers=False
-            )
-            self.assertTrue(result)
+        result = validate_match_asset_relationships(
+            test_records, check_inventory_numbers=False
+        )
+        # Result should be empty list, since inv no check is disabled
+        self.assertEqual(result, [])

--- a/utils/generate_metadata_utils.py
+++ b/utils/generate_metadata_utils.py
@@ -8,14 +8,20 @@ from pathlib import Path
 
 
 def validate_match_asset_relationships(
-    metadata_records: list[dict], logger: logging.Logger | None = None
+    metadata_records: list[dict],
+    check_inventory_numbers: bool = True,
+    logger: logging.Logger | None = None,
 ) -> bool:
     """For each metadata record with a `match_asset` field, check that:
 
     1. the match_asset value actually references another record in the batch; and
-    2. the first inventory numbers of the two related records are the same.
+    2. the first inventory numbers of the two related records are the same
+        (if `check_inventory_numbers` is True).
 
     :param metadata_records: List of metadata records.
+    :param check_inventory_numbers: Whether to check that the first inventory numbers
+        of the two related records are the same (defaults to True).
+    :param logger: Logger to use for logging. If not provided, the default logger will be used.
     :return: True if all match_asset relationships are valid, False otherwise.
     """
     _logger = logger or logging.getLogger(__name__)
@@ -39,18 +45,20 @@ def validate_match_asset_relationships(
             )
             return False
 
-        # Now check inventory numbers, using the first inv no for each record
-        record_inv = (record.get("inventory_numbers") or [None])[0]
-        matched_record_inv = (matched_record.get("inventory_numbers") or [None])[0]
+        if check_inventory_numbers:
+            # Now check inventory numbers, using the first inv no for each record
+            record_inv = (record.get("inventory_numbers") or [None])[0]
+            matched_record_inv = (matched_record.get("inventory_numbers") or [None])[0]
 
-        # Fail validation if inventory numbers do not match
-        if record_inv != matched_record_inv:
-            _logger.error(
-                f"Inventory numbers do not match for match_asset relationship "
-                f"{record['record_type']} {record['uuid']}: '{record_inv}', "
-                f"{matched_record['record_type']} {matched_record['uuid']}: '{matched_record_inv}'"
-            )
-            return False
+            # Fail validation if inventory numbers do not match
+            if record_inv != matched_record_inv:
+                _logger.error(
+                    f"Inventory numbers do not match for match_asset relationship: "
+                    f"{record['record_type']} {record['uuid']}: '{record_inv}', "
+                    f"{matched_record['record_type']} {matched_record['uuid']}: "
+                    f"'{matched_record_inv}'"
+                )
+                return False
     return True
 
 

--- a/utils/generate_metadata_utils.py
+++ b/utils/generate_metadata_utils.py
@@ -10,8 +10,7 @@ from pathlib import Path
 def validate_match_asset_relationships(
     metadata_records: list[dict],
     check_inventory_numbers: bool = True,
-    logger: logging.Logger | None = None,
-) -> bool:
+) -> list[str]:
     """For each metadata record with a `match_asset` field, check that:
 
     1. the match_asset value actually references another record in the batch; and
@@ -21,15 +20,14 @@ def validate_match_asset_relationships(
     :param metadata_records: List of metadata records.
     :param check_inventory_numbers: Whether to check that the first inventory numbers
         of the two related records are the same (defaults to True).
-    :param logger: Logger to use for logging. If not provided, the default logger will be used.
-    :return: True if all match_asset relationships are valid, False otherwise.
+    :return: A list of validation problems, if any.
     """
-    _logger = logger or logging.getLogger(__name__)
     # Index records by UUID for quick lookup below
     records_by_uuid = {
         record["uuid"]: record for record in metadata_records if record.get("uuid")
     }
 
+    validation_problems = []
     for record in metadata_records:
         # Skip records without a `match_asset` field
         match_asset_uuid = record.get("match_asset")
@@ -37,29 +35,28 @@ def validate_match_asset_relationships(
             continue
 
         matched_record = records_by_uuid.get(match_asset_uuid)
-        # Fail validation if the match_asset is not found in the batch
+        # Append a message if the match_asset is not found in the batch,
+        # then move on to the next record
         if not matched_record:
-            _logger.error(
-                f"Match asset {match_asset_uuid} for record {record['uuid']} "
-                f"not found in batch."
+            validation_problems.append(
+                f"Match asset {match_asset_uuid} for record {record['uuid']} not found in batch."
             )
-            return False
+            continue
 
         if check_inventory_numbers:
             # Now check inventory numbers, using the first inv no for each record
             record_inv = (record.get("inventory_numbers") or [None])[0]
             matched_record_inv = (matched_record.get("inventory_numbers") or [None])[0]
 
-            # Fail validation if inventory numbers do not match
+            # Append a message if the inventory numbers do not match
             if record_inv != matched_record_inv:
-                _logger.error(
+                validation_problems.append(
                     f"Inventory numbers do not match for match_asset relationship: "
                     f"{record['record_type']} {record['uuid']}: '{record_inv}', "
                     f"{matched_record['record_type']} {matched_record['uuid']}: "
                     f"'{matched_record_inv}'"
                 )
-                return False
-    return True
+    return validation_problems
 
 
 def count_assets_and_tracks(metadata_records: list[dict]) -> tuple[int, int]:

--- a/utils/generate_metadata_utils.py
+++ b/utils/generate_metadata_utils.py
@@ -45,8 +45,8 @@ def validate_match_asset_relationships(
 
         if check_inventory_numbers:
             # Now check inventory numbers, using the first inv no for each record
-            record_inv = (record.get("inventory_numbers") or [None])[0]
-            matched_record_inv = (matched_record.get("inventory_numbers") or [None])[0]
+            record_inv = record.get("inventory_numbers", [None])[0]
+            matched_record_inv = matched_record.get("inventory_numbers", [None])[0]
 
             # Append a message if the inventory numbers do not match
             if record_inv != matched_record_inv:


### PR DESCRIPTION
Implements [DLSR-463](https://uclalibrary.atlassian.net/browse/DLSR-463)

## Acceptance criteria
- [X] The check for matching inventory numbers between tracks and assets in `utils.generate_metadata_utils.validate_match_asset_relationships` is made optional
- [X] Consumers of the function are updated accordingly

## Description
Per discussion [on Slack](https://uclalibrary.slack.com/archives/C0893DA0TL0/p1783717736894839), the validation rules for legacy and NDM metadata should be different, with legacy metadata requiring that: 1) the value of the match_asset field on a track actually refers to a UUID of an item in the batch; and 2) the inventory numbers between the related items match. However, NDM metadata only needs to satisfy the first check.

This PR makes the inventory number comparison optional in the validation utility that is called in both the legacy and new media metadata generation scripts.

The `ftva-etl` package is also updated to `v0.6.0`

## Testing
1 new unit test is added to cover the validation utility with `check_inventory_numbers = False`, and a bug causing a failing test is fixed. There are 37 tests all passing: `python -m unittest`

Using the "NDM_Media to Ingest into MAMs" Google Sheet as input (can share separately, as the link is publicly accessible), running `python generate_metadata_new_media.py -c {TOML_CONFIG} -i {PATH_TO_SPREADSHEET_CSV}` should return the following error, resulting from an underlying data quality issue in Filemaker. The `creation_date` field in FM is not allowed to be anything other than a date, so the value `?` is raising this error, which is the desired behavior.

**Expected error**
```
  File "/home/ftva_data/project/generate_metadata_new_media.py", line 116, in _get_metadata_records
    metadata_record = get_mams_metadata_ndm(
        item_record, inventory_record, alma_bib_record, match_asset, nlp_model
    )
  File "/home/ftva_data/.local/lib/python3.13/site-packages/ftva_etl/metadata/mams_metadata_ndm.py", line 74, in get_mams_metadata_ndm
    "creation_date": get_creation_date(fm_item_record),
                     ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/ftva_data/.local/lib/python3.13/site-packages/ftva_etl/metadata/filemaker.py", line 141, in get_creation_date
    raise ValueError(message) from e
ValueError: Failed to parse creation date for record 99: '?' cannot be parsed to a date
```

Using a test copy of the full batch CSV with only the first 5 rows should result in a successful output.

[DLSR-463]: https://uclalibrary.atlassian.net/browse/DLSR-463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ