### PR TITLE
DLSR-478: Improve error handling to collect all errors before exiting

### DIFF
--- a/generate_metadata_new_media.py
+++ b/generate_metadata_new_media.py
@@ -79,13 +79,16 @@ def _get_item_record_by_uuid(fm_client: FilemakerClient, uuid: str) -> Record:
 # ---------------------------------------------------------------------------
 # Metadata generation
 # ---------------------------------------------------------------------------
-def _get_metadata_records(config: dict, input_data: list[dict]) -> list[dict]:
+def _get_metadata_records(
+    config: dict, input_data: list[dict]
+) -> tuple[list[dict], bool]:
     """Get metadata records for MAMS ingest,
     using input data to fetch necessary sources from Filemaker and possibly Alma.
 
     :param config: Config dict with API credentials.
     :param input_data: Input data as a list of dicts.
-    :return: A list of metadata records.
+    :return: A tuple of a list of metadata records
+        and a boolean indicating if there are errors with the batch.
     """
     # Load spacy model used by `ftva_etl` once per batch,
     # to avoid loading it in the package for each record
@@ -99,6 +102,7 @@ def _get_metadata_records(config: dict, input_data: list[dict]) -> list[dict]:
     alma_sru_client = AlmaSRUClient()
 
     metadata_records = []
+    has_errors = False
     for row in input_data:
         # Get item record by provided UUID,
         # then get inventory record using `inventory_id_fk` from item record
@@ -113,11 +117,18 @@ def _get_metadata_records(config: dict, input_data: list[dict]) -> list[dict]:
         # Set match asset if present
         match_asset = row["match asset UUID"].strip() or None
 
-        metadata_record = get_mams_metadata_ndm(
-            item_record, inventory_record, alma_bib_record, match_asset, nlp_model
-        )
-        metadata_records.append(metadata_record)
-    return metadata_records
+        try:
+            metadata_record = get_mams_metadata_ndm(
+                item_record, inventory_record, alma_bib_record, match_asset, nlp_model
+            )
+            metadata_records.append(metadata_record)
+        except (ValueError, TypeError) as e:
+            LOGGER.error(
+                f"Error generating metadata for UUID {row['UUID']}: {e}. Skipping."
+            )
+            has_errors = True
+            continue
+    return metadata_records, has_errors
 
 
 # ---------------------------------------------------------------------------
@@ -177,7 +188,13 @@ def main() -> None:
     input_data = gm_utils.read_input_file(args.input_file)
     LOGGER.info(f"Loaded {len(input_data)} input records from {args.input_file}")
 
-    metadata_records = _get_metadata_records(config, input_data)
+    metadata_records, has_errors = _get_metadata_records(config, input_data)
+
+    if has_errors:
+        LOGGER.error(
+            "Errors occurred during metadata generation. Review logs for details."
+        )
+        return
 
     # If there are any validation problems, log them and exit without writing output file.
     # Inventory numbers are expected to differ for NDM, so we disable inventory number validation.


### PR DESCRIPTION
## Acceptance criteria
- [X] While iterating input records in `generate_metadata_new_media._get_metadata_records`, errors raised by calls to `ftva-etl.get_mams_metadata_ndm` are logged and the script continues
- [X] The script prints a message flagging errors before exiting gracefully, rather than failing with stack trace

## Description
Improves handling of errors raised by `ftva-etl.get_mams_metadata_ndm()` by wrapping the caller in a `try...except` block, which logs and continues after anticipated errors, rather than exiting on the first such error. This has the benefit that the whole batch (i.e. every row in the input CSV file) can be seen by the script before gracefully exiting with a message to "review logs for details", as opposed to crashing with a stack trace on every individual error.

For consistency's sake, we could assemble a list of messages then print them if there are any, like in #62. But for some reason, the way it is here scans more clearly to me in this context...

## Testing
No new unit tests added; 37 existing tests still pass.

Using the "NDM_Media to Ingest into MAMs" Google Sheet as input, running `python generate_metadata_new_media.py -c {TOML_CONFIG} -i {PATH_TO_SPREADSHEET_CSV}` should complete successfully, with a valid JSON output. It seems that the FM data quality issue related to the `creation_date` field was resolved, though I'll confirm that on Slack.