### PR TITLE
DLSR-482: Validate Creation_date in NDM layout

### DIFF
--- a/filemaker_validation_report.py
+++ b/filemaker_validation_report.py
@@ -132,12 +132,12 @@ def _check_null(value: str) -> list[str]:
 
 
 def _check_valid_date(value: str) -> list[str]:
-    """Field must be a valid date in format returned by FM API (MM/DD/YYYY)."""
+    """Field must be a valid date in YYYY-MM-DD format."""
     try:
-        datetime.strptime(value, "%m/%d/%Y")
+        datetime.strptime(value, "%Y-%m-%d")
         return []
     except ValueError:
-        return [f"Field value {value!r} is not a valid date in MM/DD/YYYY format."]
+        return [f"Field value {value!r} is not a valid date in YYYY-MM-DD format."]
 
 
 # ---------------------------------------------------------------------------
@@ -500,6 +500,8 @@ def _get_records_for_layout(
         records = fm_client.find_all_records(
             query=[query_criterion],
             page_size=args.page_size,
+            # Set dateformats for ISO 8601 format, since otherwise the API returns MM/DD/YY
+            date_format="iso-8601",
         )
     else:
         # DS layout with no date range: no find criteria, iterate all records.

--- a/filemaker_validation_report.py
+++ b/filemaker_validation_report.py
@@ -131,6 +131,15 @@ def _check_null(value: str) -> list[str]:
     return []
 
 
+def _check_valid_date(value: str) -> list[str]:
+    """Field must be a valid date in format returned by FM API (MM/DD/YYYY)."""
+    try:
+        datetime.strptime(value, "%m/%d/%Y")
+        return []
+    except ValueError:
+        return [f"Field value {value!r} is not a valid date in MM/DD/YYYY format."]
+
+
 # ---------------------------------------------------------------------------
 # Layout -> flat field -> validators mapping
 # ---------------------------------------------------------------------------
@@ -192,7 +201,7 @@ PORTAL_FIELD_VALIDATORS: dict[str, dict[str, list[Callable]]] = {
     DC_PORTAL: {
         "Item_unit_number": [_check_null],
         "file_size_display": [_check_null],
-        "Creation_date": [_check_null],
+        "Creation_date": [_check_null, _check_valid_date],
         "audio_class": [_check_null],
         "file_path": [_check_null],
     },


### PR DESCRIPTION
Implements [DLSR-482](https://uclalibrary.atlassian.net/browse/DLSR-482)

Adds a new validator, `_check_valid_date()`, for use with the `Creation_date` field on the NDM (`NEW DIGITAL_API`) layout. 

The script now specifies a format for all dates requested from the API (ISO-8601, instead of the default MM/DD/YY). This should not affect anything else for now - currently, other datelike fields only use `_check_null()`. 

To run the script against all 30 records in the NDM layout (and find no violations for `Creation_date`):
```
docker compose exec ftva_data python filemaker_validation_report.py \
    --config_file prod_config_secrets.toml \
    --layout "NEW DIGITAL_API"
```

[DLSR-428]: https://uclalibrary.atlassian.net/browse/DLSR-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DLSR-482]: https://uclalibrary.atlassian.net/browse/DLSR-482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ