### PR TITLE
DLSR-485: Fix bug related to Unicode encoding

### DIFF
--- a/utils/generate_metadata_utils.py
+++ b/utils/generate_metadata_utils.py
@@ -92,7 +92,7 @@ def write_output_file(output_file: str | Path, data: dict | list[dict]) -> None:
     # Allows for `output_file` to be a relative path.
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, mode="w", encoding="utf-8") as file:
-        json.dump(data, file, indent=4)
+        json.dump(data, file, indent=4, ensure_ascii=False)
 
 
 def get_config(config_file_name: str) -> dict:


### PR DESCRIPTION
Fixes [DLSR-485](https://uclalibrary.atlassian.net/browse/DLSR-485)

## Bug description
- In the JSON output from `generate_metadata_new_media.py`, there was at least one record with an escaped Unicode character in the `title` field (i.e. `{..."title": "She Don\u2019t Fade"...}`). The character should be output normally, rather than in its escaped form.

## Fix
`generate_metadata_new_media.py` calls `utils.generate_metadata_utils.write_output_file` to handle writing the metadata dict to a JSON file. Setting `ensure_ascii=False` on `json.dump` in the writing utility resolves the issue with the escaped single right quotation mark (`\u2019`), and it should address similar issues.

If we want a more targeted approach, we could create a mapping in `ftva-etl` to replace certain Unicode characters, such as punctuation marks, with their ASCII equivalents, but I don't really think that's necessary. This is a one-line change, where as that would be more involved.

## Tests
No practical unit tests to add, but please confirm the single quote looks un-escaped by re-generating the JSON for the current batch. My IDE highlights the character and gives a message that says `The character U+2019 "’" could be confused with the ASCII character U+0060...`


[DLSR-485]: https://uclalibrary.atlassian.net/browse/DLSR-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ