### PR TITLE
DLSR-513: Update `ftva-etl` to `v0.6.2` in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Install `ftva-etl` package
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.6.1
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.6.2
 xmltodict==0.14.2
 # For Excel conversion
 pandas==2.2.3


### PR DESCRIPTION
## Acceptance criteria
- The `ftva-etl` version is updated to `v0.6.2` in `requirements.txt`

## Description
Updates the package to its latest version, bringing in recent changes to field name outputs.

## Testing
No new unit tests, and all existing tests still pass.