### PR TITLE
DLSR-512: add start/end date params to batch update call in scheduled script

### DIFF
--- a/run_filemaker_scripts.sh
+++ b/run_filemaker_scripts.sh
@@ -16,6 +16,8 @@ VALIDATION_CSVS=()
 uv run filemaker_batch_update.py \
   --config_file prod_config_secrets.toml \
   -f production_type Language director release_broadcast_year record_date \
+  --start_date "$START_DATE" \
+  --end_date "$END_DATE" \
   > "$BATCH_LOG" 2>&1
 
 for LAYOUT in "${LAYOUTS[@]}"; do


### PR DESCRIPTION
Implements [DLSR-512](https://uclalibrary.atlassian.net/browse/DLSR-512)

A very simple change to `run_filemaker_scripts.sh` to use the recently-added start/end date parameters when calling the batch update script. These use the same values as the reporting script (today's date for `--end_date`, two weeks ago for `--start_date`. This update brings the repo in line with the code already on `exlsupport01`.

[DLSR-512]: https://uclalibrary.atlassian.net/browse/DLSR-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ