### PR TITLE
DLSR-533: Update `ftva-etl` to `v0.7.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Install `ftva-etl` package
-git+https://github.com/UCLALibrary/ftva-etl.git@v0.6.3
+git+https://github.com/UCLALibrary/ftva-etl.git@v0.7.0
 xmltodict==0.14.2
 # For Excel conversion
 pandas==2.2.3


### PR DESCRIPTION
Implements [DLSR-533](https://uclalibrary.atlassian.net/browse/DLSR-533)

## Acceptance criteria
- [X] The `ftva-etl` version is updated to `v0.7.0` in `requirements.txt`

## Description
Updates the package to its latest version.

## Testing
No new unit tests, and all existing tests still pass.

[DLSR-533]: https://uclalibrary.atlassian.net/browse/DLSR-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ